### PR TITLE
Add avatar support + remove krisp

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Web Voice Assistant
 
-This is a starter template for [LiveKit Agents](https://docs.livekit.io/agents/overview/) that provides a simple voice interface using the [LiveKit JavaScript SDK](https://github.com/livekit/client-sdk-js).
+This is a starter template for [LiveKit Agents](https://docs.livekit.io/agents) that provides a simple voice interface using the [LiveKit JavaScript SDK](https://github.com/livekit/client-sdk-js). It supports [voice](https://docs.livekit.io/agents/start/voice-ai), [transcriptions](https://docs.livekit.io/agents/build/text/), and [virtual avatars](https://docs.livekit.io/agents/integrations/avatar).
 
 This template is built with Next.js and is free for you to use or modify as you see fit.
 
@@ -28,7 +28,7 @@ pnpm dev
 
 And open http://localhost:3000 in your browser.
 
-You'll also need an agent to speak with. Try our sample voice assistant agent for [Python](https://github.com/livekit-examples/voice-pipeline-agent-python), [Node.js](https://github.com/livekit-examples/voice-pipeline-agent-node), or [create your own from scratch](https://docs.livekit.io/agents/quickstart/).
+You'll also need an agent to speak with. Try our [Voice AI Quickstart](https://docs.livekit.io/start/voice-ai) for the easiest way to get started.
 
 > [!NOTE]
 > If you need to modify the LiveKit project credentials used, you can edit `.env.local` (copy from `.env.example` if you don't have one) to suit your needs.

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,7 @@
 import "@livekit/components-styles";
+import { Metadata } from "next";
 import { Public_Sans } from "next/font/google";
 import "./globals.css";
-import { Metadata } from "next";
 
 const publicSans400 = Public_Sans({
   weight: "400",
@@ -9,7 +9,7 @@ const publicSans400 = Public_Sans({
 });
 
 export const metadata: Metadata = {
-  title: 'Voice Assistant',
+  title: "Voice Assistant",
 };
 
 export default function RootLayout({

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,11 +1,16 @@
 import "@livekit/components-styles";
 import { Public_Sans } from "next/font/google";
 import "./globals.css";
+import { Metadata } from "next";
 
 const publicSans400 = Public_Sans({
   weight: "400",
   subsets: ["latin"],
 });
+
+export const metadata: Metadata = {
+  title: 'Voice Assistant',
+};
 
 export default function RootLayout({
   children,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -61,37 +61,51 @@ export default function Page() {
 }
 
 function SimpleVoiceAssistant(props: { onConnectButtonClicked: () => void }) {
-  const { state: agentState } = useVoiceAssistant();
+  const { state: agentState, audioTrack } = useVoiceAssistant();
   return (
-    <>
-      <AnimatePresence>
-        {agentState === "disconnected" && (
-          <motion.button
-            initial={{ opacity: 0, top: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0, top: "-10px" }}
-            transition={{ duration: 1, ease: [0.09, 1.04, 0.245, 1.055] }}
-            className="uppercase absolute left-1/2 -translate-x-1/2 px-4 py-2 bg-white text-black rounded-md"
-            onClick={() => props.onConnectButtonClicked()}
-          >
-            Start a conversation
-          </motion.button>
-        )}
-        <div className="w-3/4 lg:w-1/2 mx-auto h-full">
-          <TranscriptionView />
-        </div>
-      </AnimatePresence>
-
+    <div className="lk-room-container grid grid-rows-[2fr_1fr] items-center">
+      <div className="h-[300px] max-w-[90vw] mx-auto">
+        <BarVisualizer
+          state={agentState}
+          barCount={5}
+          trackRef={audioTrack}
+          className="agent-visualizer"
+          options={{ minHeight: 24 }}
+        />
+      </div>
+      <ControlBar onConnectButtonClicked={props.onConnectButtonClicked} />
       <RoomAudioRenderer />
       <NoAgentNotification state={agentState} />
-      <div className="fixed bottom-0 w-full px-4 py-2">
-        <ControlBar />
-      </div>
-    </>
+    </div>
+    // <>
+    //   <AnimatePresence>
+    //     {agentState === "disconnected" && (
+    //       <motion.button
+    //         initial={{ opacity: 0, top: 0 }}
+    //         animate={{ opacity: 1 }}
+    //         exit={{ opacity: 0, top: "-10px" }}
+    //         transition={{ duration: 1, ease: [0.09, 1.04, 0.245, 1.055] }}
+    //         className="uppercase absolute left-1/2 -translate-x-1/2 px-4 py-2 bg-white text-black rounded-md"
+    //         onClick={() => props.onConnectButtonClicked()}
+    //       >
+    //         Start a conversation
+    //       </motion.button>
+    //     )}
+    //     <div className="w-3/4 lg:w-1/2 mx-auto h-full">
+    //       <TranscriptionView />
+    //     </div>
+    //   </AnimatePresence>
+
+    //   <RoomAudioRenderer />
+    //   <NoAgentNotification state={agentState} />
+    //   <div className="fixed bottom-0 w-full px-4 py-2">
+    //     <ControlBar />
+    //   </div>
+    // </>
   );
 }
 
-function ControlBar() {
+function ControlBar(props: { onConnectButtonClicked: () => void }) {
   /**
    * Use Krisp background noise reduction when available.
    * Note: This is only available on Scale plan, see {@link https://livekit.io/pricing | LiveKit Pricing} for more details.
@@ -106,15 +120,34 @@ function ControlBar() {
   return (
     <div className="relative h-[100px]">
       <AnimatePresence>
-        {agentState !== "disconnected" && agentState !== "connecting" && (
+      {agentState === "disconnected" && (
+           <motion.button
+             initial={{ opacity: 0, top: 0 }}
+             animate={{ opacity: 1 }}
+             exit={{ opacity: 0, top: "-10px" }}
+             transition={{ duration: 1, ease: [0.09, 1.04, 0.245, 1.055] }}
+             className="uppercase absolute left-1/2 -translate-x-1/2 px-4 py-2 bg-white text-black rounded-md"
+             onClick={() => props.onConnectButtonClicked()}
+           >
+             Start a conversation
+           </motion.button>
+         )}
+       </AnimatePresence>
+       <AnimatePresence>
+       {agentState !== "disconnected" && agentState !== "connecting" && (
+        // {agentState !== "disconnected" && agentState !== "connecting" && (
           <motion.div
             initial={{ opacity: 0, top: "10px" }}
             animate={{ opacity: 1, top: 0 }}
             exit={{ opacity: 0, top: "-10px" }}
             transition={{ duration: 0.4, ease: [0.09, 1.04, 0.245, 1.055] }}
-            className="flex absolute w-full h-full justify-between px-8 sm:px-4"
+            className="flex h-8 absolute left-1/2 -translate-x-1/2  justify-center"
           >
-            <BarVisualizer
+             <VoiceAssistantControlBar controls={{ leave: false }} />
+             <DisconnectButton>
+               <CloseIcon />
+             </DisconnectButton>
+            {/* <BarVisualizer
               state={agentState}
               barCount={5}
               trackRef={audioTrack}
@@ -126,7 +159,7 @@ function ControlBar() {
               <DisconnectButton>
                 <CloseIcon />
               </DisconnectButton>
-            </div>
+            </div> */}
           </motion.div>
         )}
       </AnimatePresence>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -77,31 +77,6 @@ function SimpleVoiceAssistant(props: { onConnectButtonClicked: () => void }) {
       <RoomAudioRenderer />
       <NoAgentNotification state={agentState} />
     </div>
-    // <>
-    //   <AnimatePresence>
-    //     {agentState === "disconnected" && (
-    //       <motion.button
-    //         initial={{ opacity: 0, top: 0 }}
-    //         animate={{ opacity: 1 }}
-    //         exit={{ opacity: 0, top: "-10px" }}
-    //         transition={{ duration: 1, ease: [0.09, 1.04, 0.245, 1.055] }}
-    //         className="uppercase absolute left-1/2 -translate-x-1/2 px-4 py-2 bg-white text-black rounded-md"
-    //         onClick={() => props.onConnectButtonClicked()}
-    //       >
-    //         Start a conversation
-    //       </motion.button>
-    //     )}
-    //     <div className="w-3/4 lg:w-1/2 mx-auto h-full">
-    //       <TranscriptionView />
-    //     </div>
-    //   </AnimatePresence>
-
-    //   <RoomAudioRenderer />
-    //   <NoAgentNotification state={agentState} />
-    //   <div className="fixed bottom-0 w-full px-4 py-2">
-    //     <ControlBar />
-    //   </div>
-    // </>
   );
 }
 
@@ -135,7 +110,6 @@ function ControlBar(props: { onConnectButtonClicked: () => void }) {
        </AnimatePresence>
        <AnimatePresence>
        {agentState !== "disconnected" && agentState !== "connecting" && (
-        // {agentState !== "disconnected" && agentState !== "connecting" && (
           <motion.div
             initial={{ opacity: 0, top: "10px" }}
             animate={{ opacity: 1, top: 0 }}
@@ -147,19 +121,6 @@ function ControlBar(props: { onConnectButtonClicked: () => void }) {
              <DisconnectButton>
                <CloseIcon />
              </DisconnectButton>
-            {/* <BarVisualizer
-              state={agentState}
-              barCount={5}
-              trackRef={audioTrack}
-              className="agent-visualizer w-24 gap-2"
-              options={{ minHeight: 12 }}
-            />
-            <div className="flex items-center">
-              <VoiceAssistantControlBar controls={{ leave: false }} />
-              <DisconnectButton>
-                <CloseIcon />
-              </DisconnectButton>
-            </div> */}
           </motion.div>
         )}
       </AnimatePresence>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -63,8 +63,8 @@ export default function Page() {
 function SimpleVoiceAssistant(props: { onConnectButtonClicked: () => void }) {
   const { state: agentState, audioTrack } = useVoiceAssistant();
   return (
-    <div className="lk-room-container grid grid-rows-[2fr_1fr] items-center">
-      <div className="h-[300px] max-w-[90vw] mx-auto">
+    <div className="lk-room-container grid grid-rows-[1fr_auto_1fr] items-center gap-4 max-w-[1024px] w-[90vw] mx-auto">
+      <div className="h-[300px] w-full">
         <BarVisualizer
           state={agentState}
           barCount={5}
@@ -72,8 +72,8 @@ function SimpleVoiceAssistant(props: { onConnectButtonClicked: () => void }) {
           className="agent-visualizer"
           options={{ minHeight: 24 }}
         />
-        <TranscriptionView />
       </div>
+      <TranscriptionView />
       <ControlBar onConnectButtonClicked={props.onConnectButtonClicked} />
       <RoomAudioRenderer />
       <NoAgentNotification state={agentState} />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -51,7 +51,7 @@ export default function Page() {
   return (
     <main data-lk-theme="default" className="h-full grid content-center bg-[var(--lk-bg)]">
       <RoomContext.Provider value={room}>
-        <div className="lk-room-container max-h-[90vh]">
+        <div className="lk-room-container max-w-[1024px] w-[90vw] mx-auto max-h-[90vh]">
           <SimpleVoiceAssistant onConnectButtonClicked={onConnectButtonClicked} />
         </div>
       </RoomContext.Provider>
@@ -63,7 +63,7 @@ function SimpleVoiceAssistant(props: { onConnectButtonClicked: () => void }) {
   const { state: agentState, audioTrack } = useVoiceAssistant();
   
   return (
-    <div className="lk-room-container max-w-[1024px] w-[90vw] mx-auto">
+    <>
       <AnimatePresence mode="wait">
         {agentState === "disconnected" ? (
           <motion.div
@@ -91,9 +91,9 @@ function SimpleVoiceAssistant(props: { onConnectButtonClicked: () => void }) {
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: -20 }}
             transition={{ duration: 0.3, ease: [0.09, 1.04, 0.245, 1.055] }}
-            className="grid grid-rows-[1fr_auto_1fr] items-center gap-4"
+            className="flex flex-col items-center gap-4 h-full"
           >
-            <div className="h-[300px] w-full mt-[200px]">
+            <div className="h-[300px] w-full">
               <BarVisualizer
                 state={agentState}
                 barCount={5}
@@ -102,14 +102,18 @@ function SimpleVoiceAssistant(props: { onConnectButtonClicked: () => void }) {
                 options={{ minHeight: 24 }}
               />
             </div>
-            <TranscriptionView />
-            <ControlBar onConnectButtonClicked={props.onConnectButtonClicked} />
+            <div className="flex-1 w-full">
+              <TranscriptionView />
+            </div>
+            <div className="w-full">
+              <ControlBar onConnectButtonClicked={props.onConnectButtonClicked} />
+            </div>
             <RoomAudioRenderer />
             <NoAgentNotification state={agentState} />
           </motion.div>
         )}
       </AnimatePresence>
-    </div>
+    </>
   );
 }
 
@@ -117,7 +121,7 @@ function ControlBar(props: { onConnectButtonClicked: () => void }) {
   const { state: agentState, audioTrack } = useVoiceAssistant();
 
   return (
-    <div className="relative h-[100px]">
+    <div className="relative h-[60px]">
       <AnimatePresence>
       {agentState === "disconnected" && (
            <motion.button

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,6 +10,7 @@ import {
   RoomContext,
   VoiceAssistantControlBar,
   useVoiceAssistant,
+  VideoTrack,
 } from "@livekit/components-react";
 import { AnimatePresence, motion } from "framer-motion";
 import { Room, RoomEvent } from "livekit-client";
@@ -93,15 +94,7 @@ function SimpleVoiceAssistant(props: { onConnectButtonClicked: () => void }) {
             transition={{ duration: 0.3, ease: [0.09, 1.04, 0.245, 1.055] }}
             className="flex flex-col items-center gap-4 h-full"
           >
-            <div className="h-[300px] w-full">
-              <BarVisualizer
-                state={agentState}
-                barCount={5}
-                trackRef={audioTrack}
-                className="agent-visualizer"
-                options={{ minHeight: 24 }}
-              />
-            </div>
+            <AgentVisualizer />
             <div className="flex-1 w-full">
               <TranscriptionView />
             </div>
@@ -114,6 +107,23 @@ function SimpleVoiceAssistant(props: { onConnectButtonClicked: () => void }) {
         )}
       </AnimatePresence>
     </>
+  );
+}
+
+function AgentVisualizer() {
+  const { state: agentState, videoTrack, audioTrack } = useVoiceAssistant();
+
+  if (videoTrack) {
+    return (
+      <div className="h-[300px] w-full">
+        <VideoTrack trackRef={videoTrack} />
+      </div>
+    );
+  }
+  return (
+    <div className="h-[300px] w-full">
+      <BarVisualizer state={agentState} barCount={5} trackRef={audioTrack} className="agent-visualizer" options={{ minHeight: 24 }} />
+    </div>
   );
 }
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,9 +8,9 @@ import {
   DisconnectButton,
   RoomAudioRenderer,
   RoomContext,
+  VideoTrack,
   VoiceAssistantControlBar,
   useVoiceAssistant,
-  VideoTrack,
 } from "@livekit/components-react";
 import { AnimatePresence, motion } from "framer-motion";
 import { Room, RoomEvent } from "livekit-client";
@@ -62,7 +62,7 @@ export default function Page() {
 
 function SimpleVoiceAssistant(props: { onConnectButtonClicked: () => void }) {
   const { state: agentState, audioTrack } = useVoiceAssistant();
-  
+
   return (
     <>
       <AnimatePresence mode="wait">
@@ -122,7 +122,13 @@ function AgentVisualizer() {
   }
   return (
     <div className="h-[300px] w-full">
-      <BarVisualizer state={agentState} barCount={5} trackRef={audioTrack} className="agent-visualizer" options={{ minHeight: 24 }} />
+      <BarVisualizer
+        state={agentState}
+        barCount={5}
+        trackRef={audioTrack}
+        className="agent-visualizer"
+        options={{ minHeight: 24 }}
+      />
     </div>
   );
 }
@@ -133,21 +139,21 @@ function ControlBar(props: { onConnectButtonClicked: () => void }) {
   return (
     <div className="relative h-[60px]">
       <AnimatePresence>
-      {agentState === "disconnected" && (
-           <motion.button
-             initial={{ opacity: 0, top: 0 }}
-             animate={{ opacity: 1 }}
-             exit={{ opacity: 0, top: "-10px" }}
-             transition={{ duration: 1, ease: [0.09, 1.04, 0.245, 1.055] }}
-             className="uppercase absolute left-1/2 -translate-x-1/2 px-4 py-2 bg-white text-black rounded-md"
-             onClick={() => props.onConnectButtonClicked()}
-           >
-             Start a conversation
-           </motion.button>
-         )}
-       </AnimatePresence>
-       <AnimatePresence>
-       {agentState !== "disconnected" && agentState !== "connecting" && (
+        {agentState === "disconnected" && (
+          <motion.button
+            initial={{ opacity: 0, top: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0, top: "-10px" }}
+            transition={{ duration: 1, ease: [0.09, 1.04, 0.245, 1.055] }}
+            className="uppercase absolute left-1/2 -translate-x-1/2 px-4 py-2 bg-white text-black rounded-md"
+            onClick={() => props.onConnectButtonClicked()}
+          >
+            Start a conversation
+          </motion.button>
+        )}
+      </AnimatePresence>
+      <AnimatePresence>
+        {agentState !== "disconnected" && agentState !== "connecting" && (
           <motion.div
             initial={{ opacity: 0, top: "10px" }}
             animate={{ opacity: 1, top: 0 }}
@@ -155,10 +161,10 @@ function ControlBar(props: { onConnectButtonClicked: () => void }) {
             transition={{ duration: 0.4, ease: [0.09, 1.04, 0.245, 1.055] }}
             className="flex h-8 absolute left-1/2 -translate-x-1/2  justify-center"
           >
-             <VoiceAssistantControlBar controls={{ leave: false }} />
-             <DisconnectButton>
-               <CloseIcon />
-             </DisconnectButton>
+            <VoiceAssistantControlBar controls={{ leave: false }} />
+            <DisconnectButton>
+              <CloseIcon />
+            </DisconnectButton>
           </motion.div>
         )}
       </AnimatePresence>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -18,7 +18,7 @@ import { useCallback, useEffect, useState } from "react";
 import type { ConnectionDetails } from "./api/connection-details/route";
 
 export default function Page() {
-  const [room, setRoom] = useState(new Room());
+  const [room] = useState(new Room());
 
   const onConnectButtonClicked = useCallback(async () => {
     // Generate room connection details, including:
@@ -61,7 +61,7 @@ export default function Page() {
 }
 
 function SimpleVoiceAssistant(props: { onConnectButtonClicked: () => void }) {
-  const { state: agentState, audioTrack } = useVoiceAssistant();
+  const { state: agentState } = useVoiceAssistant();
 
   return (
     <>
@@ -134,7 +134,7 @@ function AgentVisualizer() {
 }
 
 function ControlBar(props: { onConnectButtonClicked: () => void }) {
-  const { state: agentState, audioTrack } = useVoiceAssistant();
+  const { state: agentState } = useVoiceAssistant();
 
   return (
     <div className="relative h-[60px]">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -115,7 +115,7 @@ function AgentVisualizer() {
 
   if (videoTrack) {
     return (
-      <div className="h-[300px] w-full">
+      <div className="h-[512px] w-[512px] rounded-lg overflow-hidden">
         <VideoTrack trackRef={videoTrack} />
       </div>
     );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -72,6 +72,7 @@ function SimpleVoiceAssistant(props: { onConnectButtonClicked: () => void }) {
           className="agent-visualizer"
           options={{ minHeight: 24 }}
         />
+        <TranscriptionView />
       </div>
       <ControlBar onConnectButtonClicked={props.onConnectButtonClicked} />
       <RoomAudioRenderer />

--- a/components/TranscriptionView.tsx
+++ b/components/TranscriptionView.tsx
@@ -3,33 +3,40 @@ import * as React from "react";
 
 export default function TranscriptionView() {
   const combinedTranscriptions = useCombinedTranscriptions();
+  const containerRef = React.useRef<HTMLDivElement>(null);
 
   // scroll to bottom when new transcription is added
   React.useEffect(() => {
-    const transcription = combinedTranscriptions[combinedTranscriptions.length - 1];
-    if (transcription) {
-      const transcriptionElement = document.getElementById(transcription.id);
-      if (transcriptionElement) {
-        transcriptionElement.scrollIntoView({ behavior: "smooth" });
-      }
+    if (containerRef.current) {
+      containerRef.current.scrollTop = containerRef.current.scrollHeight;
     }
   }, [combinedTranscriptions]);
 
   return (
-    <div className="h-full flex flex-col gap-2 overflow-y-auto">
-      {combinedTranscriptions.map((segment) => (
-        <div
-          id={segment.id}
-          key={segment.id}
-          className={
-            segment.role === "assistant"
-              ? "p-2 self-start fit-content"
-              : "bg-gray-800 rounded-md p-2 self-end fit-content"
-          }
-        >
-          {segment.text}
-        </div>
-      ))}
+    <div className="relative h-[200px] w-[768px] max-w-[90vw] mx-auto">
+      {/* Fade-out gradient mask */}
+      <div className="absolute top-0 left-0 right-0 h-8 bg-gradient-to-b from-[var(--lk-bg)] to-transparent z-10 pointer-events-none" />
+      <div className="absolute bottom-0 left-0 right-0 h-8 bg-gradient-to-t from-[var(--lk-bg)] to-transparent z-10 pointer-events-none" />
+      
+      {/* Scrollable content */}
+      <div 
+        ref={containerRef}
+        className="h-full flex flex-col gap-2 overflow-y-auto px-4 py-8"
+      >
+        {combinedTranscriptions.map((segment) => (
+          <div
+            id={segment.id}
+            key={segment.id}
+            className={
+              segment.role === "assistant"
+                ? "p-2 self-start fit-content"
+                : "bg-gray-800 rounded-md p-2 self-end fit-content"
+            }
+          >
+            {segment.text}
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/components/TranscriptionView.tsx
+++ b/components/TranscriptionView.tsx
@@ -13,7 +13,7 @@ export default function TranscriptionView() {
   }, [combinedTranscriptions]);
 
   return (
-    <div className="relative h-[200px] w-[768px] max-w-[90vw] mx-auto">
+    <div className="relative h-[200px] w-[512px] max-w-[90vw] mx-auto">
       {/* Fade-out gradient mask */}
       <div className="absolute top-0 left-0 right-0 h-8 bg-gradient-to-b from-[var(--lk-bg)] to-transparent z-10 pointer-events-none" />
       <div className="absolute bottom-0 left-0 right-0 h-8 bg-gradient-to-t from-[var(--lk-bg)] to-transparent z-10 pointer-events-none" />

--- a/components/TranscriptionView.tsx
+++ b/components/TranscriptionView.tsx
@@ -17,12 +17,9 @@ export default function TranscriptionView() {
       {/* Fade-out gradient mask */}
       <div className="absolute top-0 left-0 right-0 h-8 bg-gradient-to-b from-[var(--lk-bg)] to-transparent z-10 pointer-events-none" />
       <div className="absolute bottom-0 left-0 right-0 h-8 bg-gradient-to-t from-[var(--lk-bg)] to-transparent z-10 pointer-events-none" />
-      
+
       {/* Scrollable content */}
-      <div 
-        ref={containerRef}
-        className="h-full flex flex-col gap-2 overflow-y-auto px-4 py-8"
-      >
+      <div ref={containerRef} className="h-full flex flex-col gap-2 overflow-y-auto px-4 py-8">
         {combinedTranscriptions.map((segment) => (
           <div
             id={segment.id}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "format:write": "prettier --write ."
   },
   "dependencies": {
-    "@livekit/components-react": "^2.7.0",
+    "@livekit/components-react": "^2.9.3",
     "@livekit/components-styles": "^1.1.4",
     "framer-motion": "^11.18.0",
     "livekit-client": "^2.8.0",

--- a/package.json
+++ b/package.json
@@ -11,16 +11,12 @@
     "format:write": "prettier --write ."
   },
   "dependencies": {
-    "@livekit/components-react": "file:../../livekit/components-js/packages/react",
-    "@livekit/components-styles": "file:../../livekit/components-js/packages/styles",
+    "@livekit/components-react": "^2.7.0",
+    "@livekit/components-styles": "^1.1.4",
     "framer-motion": "^11.18.0",
     "livekit-client": "^2.8.0",
     "livekit-server-sdk": "^2.9.7",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
-  },
-  "devDependencies": {
-    "@trivago/prettier-plugin-sort-imports": "^5.2.2",
     "react-dom": "^18.3.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -11,12 +11,16 @@
     "format:write": "prettier --write ."
   },
   "dependencies": {
-    "@livekit/components-react": "^2.7.0",
-    "@livekit/components-styles": "^1.1.4",
+    "@livekit/components-react": "file:../../livekit/components-js/packages/react",
+    "@livekit/components-styles": "file:../../livekit/components-js/packages/styles",
     "framer-motion": "^11.18.0",
     "livekit-client": "^2.8.0",
     "livekit-server-sdk": "^2.9.7",
     "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@trivago/prettier-plugin-sort-imports": "^5.2.2",
     "react-dom": "^18.3.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "format:write": "prettier --write ."
   },
   "dependencies": {
-    "@livekit/components-react": "file:/Users/ben/dev/livekit/components-js/packages/react",
-    "@livekit/components-styles": "file:/Users/ben/dev/livekit/components-js/packages/styles",
+    "@livekit/components-react": "^2.7.0",
+    "@livekit/components-styles": "^1.1.4",
     "framer-motion": "^11.18.0",
     "livekit-client": "^2.8.0",
     "livekit-server-sdk": "^2.9.7",

--- a/package.json
+++ b/package.json
@@ -11,9 +11,8 @@
     "format:write": "prettier --write ."
   },
   "dependencies": {
-    "@livekit/components-react": "^2.7.0",
-    "@livekit/components-styles": "^1.1.4",
-    "@livekit/krisp-noise-filter": "^0.2.14",
+    "@livekit/components-react": "file:/Users/ben/dev/livekit/components-js/packages/react",
+    "@livekit/components-styles": "file:/Users/ben/dev/livekit/components-js/packages/styles",
     "framer-motion": "^11.18.0",
     "livekit-client": "^2.8.0",
     "livekit-server-sdk": "^2.9.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,11 +9,11 @@ importers:
   .:
     dependencies:
       '@livekit/components-react':
-        specifier: file:/Users/ben/dev/livekit/components-js/packages/react
-        version: file:../../livekit/components-js/packages/react(@livekit/krisp-noise-filter@0.2.16(livekit-client@2.11.2))(livekit-client@2.11.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)
+        specifier: ^2.7.0
+        version: 2.9.2(@livekit/krisp-noise-filter@0.2.16(livekit-client@2.11.2))(livekit-client@2.11.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)
       '@livekit/components-styles':
-        specifier: file:/Users/ben/dev/livekit/components-js/packages/styles
-        version: file:../../livekit/components-js/packages/styles
+        specifier: ^1.1.4
+        version: 1.1.5
       framer-motion:
         specifier: ^11.18.0
         version: 11.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -171,19 +171,19 @@ packages:
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
 
-  '@livekit/components-core@file:../../livekit/components-js/packages/core':
-    resolution: {directory: ../../livekit/components-js/packages/core, type: directory}
+  '@livekit/components-core@0.12.4':
+    resolution: {integrity: sha512-a/GkK8XFULPhXoSKxuXEU62gwTAYJ83DP5/vlRzwESEY+rsoiw2NvvPZtDCU17yyd/5QBIF9VdDjB9ZZF0dOfQ==}
     engines: {node: '>=18'}
     peerDependencies:
-      livekit-client: 'catalog:'
+      livekit-client: ^2.11.1
       tslib: ^2.6.2
 
-  '@livekit/components-react@file:../../livekit/components-js/packages/react':
-    resolution: {directory: ../../livekit/components-js/packages/react, type: directory}
+  '@livekit/components-react@2.9.2':
+    resolution: {integrity: sha512-VYeR1BLt0UOYj/o9FM+lAjC3q/DeyYyNFSC0d+3UCbuH6woW1l25UPN5MF4kAXSTqAjxpPWZ9hvuds2FQCyNdw==}
     engines: {node: '>=18'}
     peerDependencies:
       '@livekit/krisp-noise-filter': ^0.2.12
-      livekit-client: 'catalog:'
+      livekit-client: ^2.11.1
       react: '>=18'
       react-dom: '>=18'
       tslib: ^2.6.2
@@ -191,8 +191,8 @@ packages:
       '@livekit/krisp-noise-filter':
         optional: true
 
-  '@livekit/components-styles@file:../../livekit/components-js/packages/styles':
-    resolution: {directory: ../../livekit/components-js/packages/styles, type: directory}
+  '@livekit/components-styles@1.1.5':
+    resolution: {integrity: sha512-SocIPcwm18S28zVruvJcmiHfbUIwGTfxGbUOIp1Db78EON/iJ2v7B2g/xD5sr+c7jXoV1DNUPl2qQiFW2S9dbw==}
     engines: {node: '>=18'}
 
   '@livekit/krisp-noise-filter@0.2.16':
@@ -1966,7 +1966,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
-  '@livekit/components-core@file:../../livekit/components-js/packages/core(livekit-client@2.11.2)(tslib@2.8.1)':
+  '@livekit/components-core@0.12.4(livekit-client@2.11.2)(tslib@2.8.1)':
     dependencies:
       '@floating-ui/dom': 1.6.13
       livekit-client: 2.11.2
@@ -1974,9 +1974,9 @@ snapshots:
       rxjs: 7.8.2
       tslib: 2.8.1
 
-  '@livekit/components-react@file:../../livekit/components-js/packages/react(@livekit/krisp-noise-filter@0.2.16(livekit-client@2.11.2))(livekit-client@2.11.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)':
+  '@livekit/components-react@2.9.2(@livekit/krisp-noise-filter@0.2.16(livekit-client@2.11.2))(livekit-client@2.11.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)':
     dependencies:
-      '@livekit/components-core': file:../../livekit/components-js/packages/core(livekit-client@2.11.2)(tslib@2.8.1)
+      '@livekit/components-core': 0.12.4(livekit-client@2.11.2)(tslib@2.8.1)
       clsx: 2.1.1
       livekit-client: 2.11.2
       react: 18.3.1
@@ -1986,7 +1986,7 @@ snapshots:
     optionalDependencies:
       '@livekit/krisp-noise-filter': 0.2.16(livekit-client@2.11.2)
 
-  '@livekit/components-styles@file:../../livekit/components-js/packages/styles': {}
+  '@livekit/components-styles@1.1.5': {}
 
   '@livekit/krisp-noise-filter@0.2.16(livekit-client@2.11.2)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,11 +9,11 @@ importers:
   .:
     dependencies:
       '@livekit/components-react':
-        specifier: ^2.7.0
-        version: 2.9.2(@livekit/krisp-noise-filter@0.2.16(livekit-client@2.11.2))(livekit-client@2.11.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)
+        specifier: file:/Users/ben/dev/livekit/components-js/packages/react
+        version: file:../../livekit/components-js/packages/react(@livekit/krisp-noise-filter@0.2.16(livekit-client@2.11.2))(livekit-client@2.11.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)
       '@livekit/components-styles':
-        specifier: ^1.1.4
-        version: 1.1.5
+        specifier: file:/Users/ben/dev/livekit/components-js/packages/styles
+        version: file:../../livekit/components-js/packages/styles
       framer-motion:
         specifier: ^11.18.0
         version: 11.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -171,19 +171,19 @@ packages:
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
 
-  '@livekit/components-core@0.12.4':
-    resolution: {integrity: sha512-a/GkK8XFULPhXoSKxuXEU62gwTAYJ83DP5/vlRzwESEY+rsoiw2NvvPZtDCU17yyd/5QBIF9VdDjB9ZZF0dOfQ==}
+  '@livekit/components-core@file:../../livekit/components-js/packages/core':
+    resolution: {directory: ../../livekit/components-js/packages/core, type: directory}
     engines: {node: '>=18'}
     peerDependencies:
-      livekit-client: ^2.11.1
+      livekit-client: 'catalog:'
       tslib: ^2.6.2
 
-  '@livekit/components-react@2.9.2':
-    resolution: {integrity: sha512-VYeR1BLt0UOYj/o9FM+lAjC3q/DeyYyNFSC0d+3UCbuH6woW1l25UPN5MF4kAXSTqAjxpPWZ9hvuds2FQCyNdw==}
+  '@livekit/components-react@file:../../livekit/components-js/packages/react':
+    resolution: {directory: ../../livekit/components-js/packages/react, type: directory}
     engines: {node: '>=18'}
     peerDependencies:
       '@livekit/krisp-noise-filter': ^0.2.12
-      livekit-client: ^2.11.1
+      livekit-client: 'catalog:'
       react: '>=18'
       react-dom: '>=18'
       tslib: ^2.6.2
@@ -191,8 +191,8 @@ packages:
       '@livekit/krisp-noise-filter':
         optional: true
 
-  '@livekit/components-styles@1.1.5':
-    resolution: {integrity: sha512-SocIPcwm18S28zVruvJcmiHfbUIwGTfxGbUOIp1Db78EON/iJ2v7B2g/xD5sr+c7jXoV1DNUPl2qQiFW2S9dbw==}
+  '@livekit/components-styles@file:../../livekit/components-js/packages/styles':
+    resolution: {directory: ../../livekit/components-js/packages/styles, type: directory}
     engines: {node: '>=18'}
 
   '@livekit/krisp-noise-filter@0.2.16':
@@ -1966,7 +1966,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
-  '@livekit/components-core@0.12.4(livekit-client@2.11.2)(tslib@2.8.1)':
+  '@livekit/components-core@file:../../livekit/components-js/packages/core(livekit-client@2.11.2)(tslib@2.8.1)':
     dependencies:
       '@floating-ui/dom': 1.6.13
       livekit-client: 2.11.2
@@ -1974,9 +1974,9 @@ snapshots:
       rxjs: 7.8.2
       tslib: 2.8.1
 
-  '@livekit/components-react@2.9.2(@livekit/krisp-noise-filter@0.2.16(livekit-client@2.11.2))(livekit-client@2.11.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)':
+  '@livekit/components-react@file:../../livekit/components-js/packages/react(@livekit/krisp-noise-filter@0.2.16(livekit-client@2.11.2))(livekit-client@2.11.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)':
     dependencies:
-      '@livekit/components-core': 0.12.4(livekit-client@2.11.2)(tslib@2.8.1)
+      '@livekit/components-core': file:../../livekit/components-js/packages/core(livekit-client@2.11.2)(tslib@2.8.1)
       clsx: 2.1.1
       livekit-client: 2.11.2
       react: 18.3.1
@@ -1986,7 +1986,7 @@ snapshots:
     optionalDependencies:
       '@livekit/krisp-noise-filter': 0.2.16(livekit-client@2.11.2)
 
-  '@livekit/components-styles@1.1.5': {}
+  '@livekit/components-styles@file:../../livekit/components-js/packages/styles': {}
 
   '@livekit/krisp-noise-filter@0.2.16(livekit-client@2.11.2)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,11 +9,11 @@ importers:
   .:
     dependencies:
       '@livekit/components-react':
-        specifier: file:/Users/ben/dev/livekit/components-js/packages/react
-        version: file:../../livekit/components-js/packages/react(@livekit/krisp-noise-filter@0.2.16(livekit-client@2.11.2))(livekit-client@2.11.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)
+        specifier: ^2.9.3
+        version: 2.9.3(@livekit/krisp-noise-filter@0.2.16(livekit-client@2.11.2))(livekit-client@2.11.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)
       '@livekit/components-styles':
-        specifier: file:/Users/ben/dev/livekit/components-js/packages/styles
-        version: file:../../livekit/components-js/packages/styles
+        specifier: ^1.1.4
+        version: 1.1.5
       framer-motion:
         specifier: ^11.18.0
         version: 11.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -171,19 +171,19 @@ packages:
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
 
-  '@livekit/components-core@file:../../livekit/components-js/packages/core':
-    resolution: {directory: ../../livekit/components-js/packages/core, type: directory}
+  '@livekit/components-core@0.12.4':
+    resolution: {integrity: sha512-a/GkK8XFULPhXoSKxuXEU62gwTAYJ83DP5/vlRzwESEY+rsoiw2NvvPZtDCU17yyd/5QBIF9VdDjB9ZZF0dOfQ==}
     engines: {node: '>=18'}
     peerDependencies:
-      livekit-client: 'catalog:'
+      livekit-client: ^2.11.1
       tslib: ^2.6.2
 
-  '@livekit/components-react@file:../../livekit/components-js/packages/react':
-    resolution: {directory: ../../livekit/components-js/packages/react, type: directory}
+  '@livekit/components-react@2.9.3':
+    resolution: {integrity: sha512-gE1sEE57BkBz3+TQHrOXVDVwVMwV5wtIYokdrfd7vshh22/PtWWj3vON9wzYLFRKx98L6QyAzyh7W9EWu3Lj9Q==}
     engines: {node: '>=18'}
     peerDependencies:
       '@livekit/krisp-noise-filter': ^0.2.12
-      livekit-client: 'catalog:'
+      livekit-client: ^2.11.1
       react: '>=18'
       react-dom: '>=18'
       tslib: ^2.6.2
@@ -191,8 +191,8 @@ packages:
       '@livekit/krisp-noise-filter':
         optional: true
 
-  '@livekit/components-styles@file:../../livekit/components-js/packages/styles':
-    resolution: {directory: ../../livekit/components-js/packages/styles, type: directory}
+  '@livekit/components-styles@1.1.5':
+    resolution: {integrity: sha512-SocIPcwm18S28zVruvJcmiHfbUIwGTfxGbUOIp1Db78EON/iJ2v7B2g/xD5sr+c7jXoV1DNUPl2qQiFW2S9dbw==}
     engines: {node: '>=18'}
 
   '@livekit/krisp-noise-filter@0.2.16':
@@ -1966,7 +1966,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
-  '@livekit/components-core@file:../../livekit/components-js/packages/core(livekit-client@2.11.2)(tslib@2.8.1)':
+  '@livekit/components-core@0.12.4(livekit-client@2.11.2)(tslib@2.8.1)':
     dependencies:
       '@floating-ui/dom': 1.6.13
       livekit-client: 2.11.2
@@ -1974,9 +1974,9 @@ snapshots:
       rxjs: 7.8.2
       tslib: 2.8.1
 
-  '@livekit/components-react@file:../../livekit/components-js/packages/react(@livekit/krisp-noise-filter@0.2.16(livekit-client@2.11.2))(livekit-client@2.11.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)':
+  '@livekit/components-react@2.9.3(@livekit/krisp-noise-filter@0.2.16(livekit-client@2.11.2))(livekit-client@2.11.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)':
     dependencies:
-      '@livekit/components-core': file:../../livekit/components-js/packages/core(livekit-client@2.11.2)(tslib@2.8.1)
+      '@livekit/components-core': 0.12.4(livekit-client@2.11.2)(tslib@2.8.1)
       clsx: 2.1.1
       livekit-client: 2.11.2
       react: 18.3.1
@@ -1986,7 +1986,7 @@ snapshots:
     optionalDependencies:
       '@livekit/krisp-noise-filter': 0.2.16(livekit-client@2.11.2)
 
-  '@livekit/components-styles@file:../../livekit/components-js/packages/styles': {}
+  '@livekit/components-styles@1.1.5': {}
 
   '@livekit/krisp-noise-filter@0.2.16(livekit-client@2.11.2)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,11 +9,11 @@ importers:
   .:
     dependencies:
       '@livekit/components-react':
-        specifier: ^2.7.0
-        version: 2.9.2(@livekit/krisp-noise-filter@0.2.16(livekit-client@2.11.2))(livekit-client@2.11.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)
+        specifier: file:../../livekit/components-js/packages/react
+        version: file:../../livekit/components-js/packages/react(@livekit/krisp-noise-filter@0.2.16(livekit-client@2.11.2))(livekit-client@2.11.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)
       '@livekit/components-styles':
-        specifier: ^1.1.4
-        version: 1.1.5
+        specifier: file:../../livekit/components-js/packages/styles
+        version: file:../../livekit/components-js/packages/styles
       framer-motion:
         specifier: ^11.18.0
         version: 11.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -171,19 +171,19 @@ packages:
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
 
-  '@livekit/components-core@0.12.4':
-    resolution: {integrity: sha512-a/GkK8XFULPhXoSKxuXEU62gwTAYJ83DP5/vlRzwESEY+rsoiw2NvvPZtDCU17yyd/5QBIF9VdDjB9ZZF0dOfQ==}
+  '@livekit/components-core@file:../../livekit/components-js/packages/core':
+    resolution: {directory: ../../livekit/components-js/packages/core, type: directory}
     engines: {node: '>=18'}
     peerDependencies:
-      livekit-client: ^2.11.1
+      livekit-client: 'catalog:'
       tslib: ^2.6.2
 
-  '@livekit/components-react@2.9.2':
-    resolution: {integrity: sha512-VYeR1BLt0UOYj/o9FM+lAjC3q/DeyYyNFSC0d+3UCbuH6woW1l25UPN5MF4kAXSTqAjxpPWZ9hvuds2FQCyNdw==}
+  '@livekit/components-react@file:../../livekit/components-js/packages/react':
+    resolution: {directory: ../../livekit/components-js/packages/react, type: directory}
     engines: {node: '>=18'}
     peerDependencies:
       '@livekit/krisp-noise-filter': ^0.2.12
-      livekit-client: ^2.11.1
+      livekit-client: 'catalog:'
       react: '>=18'
       react-dom: '>=18'
       tslib: ^2.6.2
@@ -191,8 +191,8 @@ packages:
       '@livekit/krisp-noise-filter':
         optional: true
 
-  '@livekit/components-styles@1.1.5':
-    resolution: {integrity: sha512-SocIPcwm18S28zVruvJcmiHfbUIwGTfxGbUOIp1Db78EON/iJ2v7B2g/xD5sr+c7jXoV1DNUPl2qQiFW2S9dbw==}
+  '@livekit/components-styles@file:../../livekit/components-js/packages/styles':
+    resolution: {directory: ../../livekit/components-js/packages/styles, type: directory}
     engines: {node: '>=18'}
 
   '@livekit/krisp-noise-filter@0.2.16':
@@ -1966,7 +1966,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
-  '@livekit/components-core@0.12.4(livekit-client@2.11.2)(tslib@2.8.1)':
+  '@livekit/components-core@file:../../livekit/components-js/packages/core(livekit-client@2.11.2)(tslib@2.8.1)':
     dependencies:
       '@floating-ui/dom': 1.6.13
       livekit-client: 2.11.2
@@ -1974,9 +1974,9 @@ snapshots:
       rxjs: 7.8.2
       tslib: 2.8.1
 
-  '@livekit/components-react@2.9.2(@livekit/krisp-noise-filter@0.2.16(livekit-client@2.11.2))(livekit-client@2.11.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)':
+  '@livekit/components-react@file:../../livekit/components-js/packages/react(@livekit/krisp-noise-filter@0.2.16(livekit-client@2.11.2))(livekit-client@2.11.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)':
     dependencies:
-      '@livekit/components-core': 0.12.4(livekit-client@2.11.2)(tslib@2.8.1)
+      '@livekit/components-core': file:../../livekit/components-js/packages/core(livekit-client@2.11.2)(tslib@2.8.1)
       clsx: 2.1.1
       livekit-client: 2.11.2
       react: 18.3.1
@@ -1986,7 +1986,7 @@ snapshots:
     optionalDependencies:
       '@livekit/krisp-noise-filter': 0.2.16(livekit-client@2.11.2)
 
-  '@livekit/components-styles@1.1.5': {}
+  '@livekit/components-styles@file:../../livekit/components-js/packages/styles': {}
 
   '@livekit/krisp-noise-filter@0.2.16(livekit-client@2.11.2)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,11 +9,11 @@ importers:
   .:
     dependencies:
       '@livekit/components-react':
-        specifier: file:../../livekit/components-js/packages/react
-        version: file:../../livekit/components-js/packages/react(@livekit/krisp-noise-filter@0.2.16(livekit-client@2.11.2))(livekit-client@2.11.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)
+        specifier: ^2.7.0
+        version: 2.9.2(@livekit/krisp-noise-filter@0.2.16(livekit-client@2.11.2))(livekit-client@2.11.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)
       '@livekit/components-styles':
-        specifier: file:../../livekit/components-js/packages/styles
-        version: file:../../livekit/components-js/packages/styles
+        specifier: ^1.1.4
+        version: 1.1.5
       framer-motion:
         specifier: ^11.18.0
         version: 11.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -171,19 +171,19 @@ packages:
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
 
-  '@livekit/components-core@file:../../livekit/components-js/packages/core':
-    resolution: {directory: ../../livekit/components-js/packages/core, type: directory}
+  '@livekit/components-core@0.12.4':
+    resolution: {integrity: sha512-a/GkK8XFULPhXoSKxuXEU62gwTAYJ83DP5/vlRzwESEY+rsoiw2NvvPZtDCU17yyd/5QBIF9VdDjB9ZZF0dOfQ==}
     engines: {node: '>=18'}
     peerDependencies:
-      livekit-client: 'catalog:'
+      livekit-client: ^2.11.1
       tslib: ^2.6.2
 
-  '@livekit/components-react@file:../../livekit/components-js/packages/react':
-    resolution: {directory: ../../livekit/components-js/packages/react, type: directory}
+  '@livekit/components-react@2.9.2':
+    resolution: {integrity: sha512-VYeR1BLt0UOYj/o9FM+lAjC3q/DeyYyNFSC0d+3UCbuH6woW1l25UPN5MF4kAXSTqAjxpPWZ9hvuds2FQCyNdw==}
     engines: {node: '>=18'}
     peerDependencies:
       '@livekit/krisp-noise-filter': ^0.2.12
-      livekit-client: 'catalog:'
+      livekit-client: ^2.11.1
       react: '>=18'
       react-dom: '>=18'
       tslib: ^2.6.2
@@ -191,8 +191,8 @@ packages:
       '@livekit/krisp-noise-filter':
         optional: true
 
-  '@livekit/components-styles@file:../../livekit/components-js/packages/styles':
-    resolution: {directory: ../../livekit/components-js/packages/styles, type: directory}
+  '@livekit/components-styles@1.1.5':
+    resolution: {integrity: sha512-SocIPcwm18S28zVruvJcmiHfbUIwGTfxGbUOIp1Db78EON/iJ2v7B2g/xD5sr+c7jXoV1DNUPl2qQiFW2S9dbw==}
     engines: {node: '>=18'}
 
   '@livekit/krisp-noise-filter@0.2.16':
@@ -1966,7 +1966,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
-  '@livekit/components-core@file:../../livekit/components-js/packages/core(livekit-client@2.11.2)(tslib@2.8.1)':
+  '@livekit/components-core@0.12.4(livekit-client@2.11.2)(tslib@2.8.1)':
     dependencies:
       '@floating-ui/dom': 1.6.13
       livekit-client: 2.11.2
@@ -1974,9 +1974,9 @@ snapshots:
       rxjs: 7.8.2
       tslib: 2.8.1
 
-  '@livekit/components-react@file:../../livekit/components-js/packages/react(@livekit/krisp-noise-filter@0.2.16(livekit-client@2.11.2))(livekit-client@2.11.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)':
+  '@livekit/components-react@2.9.2(@livekit/krisp-noise-filter@0.2.16(livekit-client@2.11.2))(livekit-client@2.11.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)':
     dependencies:
-      '@livekit/components-core': file:../../livekit/components-js/packages/core(livekit-client@2.11.2)(tslib@2.8.1)
+      '@livekit/components-core': 0.12.4(livekit-client@2.11.2)(tslib@2.8.1)
       clsx: 2.1.1
       livekit-client: 2.11.2
       react: 18.3.1
@@ -1986,7 +1986,7 @@ snapshots:
     optionalDependencies:
       '@livekit/krisp-noise-filter': 0.2.16(livekit-client@2.11.2)
 
-  '@livekit/components-styles@file:../../livekit/components-js/packages/styles': {}
+  '@livekit/components-styles@1.1.5': {}
 
   '@livekit/krisp-noise-filter@0.2.16(livekit-client@2.11.2)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,14 +9,11 @@ importers:
   .:
     dependencies:
       '@livekit/components-react':
-        specifier: ^2.7.0
-        version: 2.9.2(@livekit/krisp-noise-filter@0.2.16(livekit-client@2.11.2))(livekit-client@2.11.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)
+        specifier: file:/Users/ben/dev/livekit/components-js/packages/react
+        version: file:../../livekit/components-js/packages/react(@livekit/krisp-noise-filter@0.2.16(livekit-client@2.11.2))(livekit-client@2.11.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)
       '@livekit/components-styles':
-        specifier: ^1.1.4
-        version: 1.1.5
-      '@livekit/krisp-noise-filter':
-        specifier: ^0.2.14
-        version: 0.2.16(livekit-client@2.11.2)
+        specifier: file:/Users/ben/dev/livekit/components-js/packages/styles
+        version: file:../../livekit/components-js/packages/styles
       framer-motion:
         specifier: ^11.18.0
         version: 11.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -174,19 +171,19 @@ packages:
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
 
-  '@livekit/components-core@0.12.4':
-    resolution: {integrity: sha512-a/GkK8XFULPhXoSKxuXEU62gwTAYJ83DP5/vlRzwESEY+rsoiw2NvvPZtDCU17yyd/5QBIF9VdDjB9ZZF0dOfQ==}
+  '@livekit/components-core@file:../../livekit/components-js/packages/core':
+    resolution: {directory: ../../livekit/components-js/packages/core, type: directory}
     engines: {node: '>=18'}
     peerDependencies:
-      livekit-client: ^2.11.1
+      livekit-client: 'catalog:'
       tslib: ^2.6.2
 
-  '@livekit/components-react@2.9.2':
-    resolution: {integrity: sha512-VYeR1BLt0UOYj/o9FM+lAjC3q/DeyYyNFSC0d+3UCbuH6woW1l25UPN5MF4kAXSTqAjxpPWZ9hvuds2FQCyNdw==}
+  '@livekit/components-react@file:../../livekit/components-js/packages/react':
+    resolution: {directory: ../../livekit/components-js/packages/react, type: directory}
     engines: {node: '>=18'}
     peerDependencies:
       '@livekit/krisp-noise-filter': ^0.2.12
-      livekit-client: ^2.11.1
+      livekit-client: 'catalog:'
       react: '>=18'
       react-dom: '>=18'
       tslib: ^2.6.2
@@ -194,8 +191,8 @@ packages:
       '@livekit/krisp-noise-filter':
         optional: true
 
-  '@livekit/components-styles@1.1.5':
-    resolution: {integrity: sha512-SocIPcwm18S28zVruvJcmiHfbUIwGTfxGbUOIp1Db78EON/iJ2v7B2g/xD5sr+c7jXoV1DNUPl2qQiFW2S9dbw==}
+  '@livekit/components-styles@file:../../livekit/components-js/packages/styles':
+    resolution: {directory: ../../livekit/components-js/packages/styles, type: directory}
     engines: {node: '>=18'}
 
   '@livekit/krisp-noise-filter@0.2.16':
@@ -1969,7 +1966,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
-  '@livekit/components-core@0.12.4(livekit-client@2.11.2)(tslib@2.8.1)':
+  '@livekit/components-core@file:../../livekit/components-js/packages/core(livekit-client@2.11.2)(tslib@2.8.1)':
     dependencies:
       '@floating-ui/dom': 1.6.13
       livekit-client: 2.11.2
@@ -1977,9 +1974,9 @@ snapshots:
       rxjs: 7.8.2
       tslib: 2.8.1
 
-  '@livekit/components-react@2.9.2(@livekit/krisp-noise-filter@0.2.16(livekit-client@2.11.2))(livekit-client@2.11.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)':
+  '@livekit/components-react@file:../../livekit/components-js/packages/react(@livekit/krisp-noise-filter@0.2.16(livekit-client@2.11.2))(livekit-client@2.11.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)':
     dependencies:
-      '@livekit/components-core': 0.12.4(livekit-client@2.11.2)(tslib@2.8.1)
+      '@livekit/components-core': file:../../livekit/components-js/packages/core(livekit-client@2.11.2)(tslib@2.8.1)
       clsx: 2.1.1
       livekit-client: 2.11.2
       react: 18.3.1
@@ -1989,11 +1986,12 @@ snapshots:
     optionalDependencies:
       '@livekit/krisp-noise-filter': 0.2.16(livekit-client@2.11.2)
 
-  '@livekit/components-styles@1.1.5': {}
+  '@livekit/components-styles@file:../../livekit/components-js/packages/styles': {}
 
   '@livekit/krisp-noise-filter@0.2.16(livekit-client@2.11.2)':
     dependencies:
       livekit-client: 2.11.2
+    optional: true
 
   '@livekit/mutex@1.1.1': {}
 


### PR DESCRIPTION
This restores the old basic layout (centered visualizer) with a smaller transcription component and the addition of avatar support in place of the visualizer.

I also removed krisp while I was at it (for agents we are now recommending devs use server-side bvc)