### PR TITLE
Update template to point to agents 1.0 instead of 0.x

### DIFF
--- a/TEMPLATE.md
+++ b/TEMPLATE.md
@@ -1,16 +1,10 @@
 ## Overview
 
-A Next.js frontend for a simple AI voice assistant using LiveKit's official [JavaScript SDK](https://github.com/livekit/client-sdk-js) and [React Components](https://github.com/livekit/components-js). The application implements its own token server, and is designed to be used with any voice-enabled agent built using [LiveKit Agents](https://docs.livekit.io/agents/).
+A Next.js frontend for a simple AI voice assistant using LiveKit's official [JavaScript SDK](https://github.com/livekit/client-sdk-js) and [React Components](https://github.com/livekit/components-js). The application implements its own token server, and supports [voice](https://docs.livekit.io/agents/start/voice-ai/), [transcription](https://docs.livekit.io/agents/build/text/), and [virtual avatars](https://docs.livekit.io/agents/integrations/avatar/).
 
 ## Sandbox
 
-When deployed in a sandbox, LiveKit will host an instance of this application for you, providing a unique, shareable URL through which you can access it. Any agents running with the same LiveKit project credentials will join, meaning that you can rapidly iterate on your agent prototypes, and share the results instantly with friends and colleagues. To begin testing your agent, deploy this app in sandbox then set up an agent on your local machine using the [LiveKit CLI](https://docs.livekit.io/home/cli/cli-setup/):
-
-```console
-lk app create --template voice-pipeline-agent-python
-```
-
-**NOTE:** For a list of all available templates, run `lk app list-templates`.
+When deployed in a sandbox, LiveKit will host an instance of this application for you, providing a unique, shareable URL through which you can access it. Any agents running with the same LiveKit project credentials will join, meaning that you can rapidly iterate on your agent prototypes, and share the results instantly with friends and colleagues. To begin testing your agent, deploy this app in sandbox then set up an agent on your local machine using the [Voice AI Quickstart](https://docs.livekit.io/start/voice-ai):
 
 ## Installation
 


### PR DESCRIPTION
I don't see a simple 1.0 compatible bootstrap agent so for now just pointing to the quickstart...