### PR TITLE
fix: mic toggle button with no input options

### DIFF
--- a/components/livekit/agent-control-bar/track-selector.tsx
+++ b/components/livekit/agent-control-bar/track-selector.tsx
@@ -44,7 +44,7 @@ export function TrackSelector({
         pending={pending}
         disabled={disabled}
         onPressedChange={onPressedChange}
-        className="peer/track group/track has-[.audiovisualizer]:w-auto has-[~_button]:rounded-r-none has-[~_button]:pr-2 has-[~_button]:pl-3"
+        className="peer/track group/track has-[.audiovisualizer]:w-auto has-[.audiovisualizer]:px-3 has-[~_button]:rounded-r-none has-[~_button]:pr-2 has-[~_button]:pl-3"
       >
         {audioTrackRef && (
           <BarVisualizer


### PR DESCRIPTION
## Issue

Mic button looks broken when there are less than 2 input options. This also happens when mic access its disabled

## Before

<img width="2400" height="1800" alt="localhost_3000_(4_3) (1)" src="https://github.com/user-attachments/assets/dcc561e2-af2f-49c1-9c76-f9ecb4700d90" />

## After

<img width="2400" height="1800" alt="localhost_3000_(4_3) (2)" src="https://github.com/user-attachments/assets/ac5954ce-9b20-43d5-849b-b53d9dc60c7a" />

