### PR TITLE
chore: update README and env vars to clarify agent name and agent dispatch responsibilities

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,10 @@ LIVEKIT_API_KEY=<your_api_key>
 LIVEKIT_API_SECRET=<your_api_secret>
 LIVEKIT_URL=wss://<project-subdomain>.livekit.cloud
 
+# Agent dispatch (https://docs.livekit.io/agents/server/agent-dispatch)
+# Leave AGENT_NAME blank to enable automatic dispatch
+# Provide an agent name to enable explicit dispatch
+AGENT_NAME=
 
 # Internally used environment variables
 NEXT_PUBLIC_APP_CONFIG_ENDPOINT=

--- a/README.md
+++ b/README.md
@@ -93,17 +93,19 @@ export const APP_CONFIG_DEFAULTS: AppConfig = {
   accentDark: '#1fd5f9',
   startButtonText: 'Start call',
 
-  // for LiveKit Cloud Sandbox
-  sandboxId: undefined,
+  // agent dispatch configuration
   agentName: undefined,
+
+  // LiveKit Cloud Sandbox configuration
+  sandboxId: undefined,
 };
 ```
 
 You can update these values in [`app-config.ts`](./app-config.ts) to customize branding, features, and UI text for your deployment.
 
 > [!NOTE]
-> The `sandboxId` and `agentName` are for the LiveKit Cloud Sandbox environment.
-> They are not used for local development.
+> The `sandboxId` is for the LiveKit Cloud Sandbox environment.
+> It is not used for local development.
 
 #### Environment Variables
 
@@ -113,6 +115,11 @@ You'll also need to configure your LiveKit credentials in `.env.local` (copy `.e
 LIVEKIT_API_KEY=your_livekit_api_key
 LIVEKIT_API_SECRET=your_livekit_api_secret
 LIVEKIT_URL=https://your-livekit-server-url
+
+# Agent dispatch (https://docs.livekit.io/agents/server/agent-dispatch)
+# Leave AGENT_NAME blank to enable automatic dispatch
+# Provide an agent name to enable explicit dispatch
+AGENT_NAME=
 ```
 
 These are required for the voice agent functionality to work with your LiveKit project.

--- a/app-config.ts
+++ b/app-config.ts
@@ -14,9 +14,11 @@ export interface AppConfig {
   logoDark?: string;
   accentDark?: string;
 
-  // for LiveKit Cloud Sandbox
-  sandboxId?: string;
+  // agent dispatch configuration
   agentName?: string;
+
+  // LiveKit Cloud Sandbox configuration
+  sandboxId?: string;
 }
 
 export const APP_CONFIG_DEFAULTS: AppConfig = {
@@ -35,7 +37,9 @@ export const APP_CONFIG_DEFAULTS: AppConfig = {
   accentDark: '#1fd5f9',
   startButtonText: 'Start call',
 
-  // for LiveKit Cloud Sandbox
+  // agent dispatch configuration
+  agentName: process.env.AGENT_NAME ?? undefined,
+
+  // LiveKit Cloud Sandbox configuration
   sandboxId: undefined,
-  agentName: undefined,
 };


### PR DESCRIPTION
## PR Summary

### Problem

README and comments state `agentName` is for LiveKit Cloud Sandbox, which is misleading because it's also necessary if you're testing with an agent that requires explicit dispatch. Agent's exported form Agent Builder default to explicit dispatch

Testing an agent using explicit dispatch requires you modify `agentName` in `app-config.ts` file which causes a git diff. This git diff could be accidentally checked in.

### Solution

Update README and comments to indicate `agentName` is part of agent dispatch configuration.

By implementing `AGENT_NAME` in `.env.local` this value will not impact git diff's or cause it to be accidentally checked in.

**Key changes:**

- **`.env.example`**: Added `AGENT_NAME` environment variable with documentation explaining automatic vs explicit dispatch modes
- **`README.md`**: Updated documentation to reflect the new configuration structure and environment variable
- **`app-config.ts`**: 
  - Read `agentName` from local env vars, default to undefined
  - update comments to clearly indicate config value purposes
