### PR TITLE
Fix screenshare support setting

### DIFF
--- a/components/app/session-view.tsx
+++ b/components/app/session-view.tsx
@@ -74,7 +74,7 @@ export const SessionView = ({
     microphone: true,
     chat: appConfig.supportsChatInput,
     camera: appConfig.supportsVideoInput,
-    screenShare: appConfig.supportsVideoInput,
+    screenShare: appConfig.supportsScreenShare,
   };
 
   useEffect(() => {


### PR DESCRIPTION
Noticed that the screen-share button was always displaying despite setting `supportsScreenShare` to `false` in `app-config.ts`, and found it was using the same setting as for video support.