### PR TITLE
docs: add LiveKit learning project with step-by-step tutorial

### DIFF
--- a/.claude/skills/generate-quiz/SKILL.md
+++ b/.claude/skills/generate-quiz/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: generate-quiz
+description: Generates quiz questions and answers for LiveKit learning steps. Use after completing a step in the learning plan, when the user says "generate quiz", "create quiz", or "quiz for step X".
+allowed-tools: Read, Write, Glob
+---
+
+# Generate Quiz Skill
+
+This skill creates comprehensive quiz questions and detailed answers for each step in the LiveKit learning journey.
+
+## Instructions
+
+When triggered, follow these steps:
+
+### 1. Identify the Step Number
+
+- If the user specifies a step (e.g., "quiz for step 2"), use that step number
+- If not specified, read `Docs/PLAN.md` and find the most recently completed step (marked with `[x]` or `✅`)
+
+### 2. Read the Step Details
+
+From `Docs/PLAN.md`, extract for the target step:
+- **What we're doing** - The task description
+- **Files** - The files created/modified
+- **What you'll learn** - Key learning points
+- **Key code to understand** - Any code snippets shown
+- **Review after completing** - Questions already suggested
+
+### 3. Read the Actual Implementation
+
+Read the files created in that step to understand:
+- The actual code written
+- Comments explaining the code
+- Patterns and concepts demonstrated
+
+### 4. Generate Questions File
+
+Create `livekit-learning/Quiz/Step-{NN}-Questions.md` with:
+
+```markdown
+# Step {N} Quiz: {Topic}
+
+Test your understanding of {topic} before moving to the next step.
+
+---
+
+## Question 1: {Conceptual Question}
+{Question about the main concept}
+
+---
+
+## Question 2: {Why Question}
+{Question asking WHY something is done a certain way}
+
+---
+
+## Question 3: {Code Understanding}
+{Question about specific code, showing a snippet}
+
+---
+
+## Question 4: {Practical Application}
+{Question about when/how to use this in practice}
+
+---
+
+## Question 5: {True/False or Multiple Choice}
+{Verification question with options}
+
+---
+
+## Question 6: {Connection Question}
+{How does this connect to previous steps or upcoming concepts?}
+
+---
+
+## Bonus Question
+{Advanced question for deeper understanding}
+
+---
+
+**When you're done, check your answers in `Step-{NN}-Answers.md`**
+```
+
+### 5. Generate Answers File
+
+Create `livekit-learning/Quiz/Step-{NN}-Answers.md` with:
+
+```markdown
+# Step {N} Answers: {Topic}
+
+Detailed explanations for each question.
+
+---
+
+## Answer 1: {Topic}
+
+**{Short answer}**
+
+{Detailed explanation with:}
+- Why this matters
+- Code examples if relevant
+- Diagrams using ASCII art if helpful
+- Common misconceptions
+
+---
+
+[Continue for all questions...]
+
+---
+
+## Summary: Key Takeaways from Step {N}
+
+1. {Takeaway 1}
+2. {Takeaway 2}
+3. {Takeaway 3}
+
+---
+
+**Ready for Step {N+1}? Move on to {next step topic}!**
+```
+
+### 6. Update Quiz README
+
+Update `livekit-learning/Quiz/README.md` to show the new quiz is available.
+
+### 7. Confirm Completion
+
+Tell the user:
+- Which step's quiz was created
+- How many questions were generated
+- Where to find the files
+- Remind them to try the questions before looking at answers
+
+## Question Types to Include
+
+Generate a mix of these question types:
+
+1. **Conceptual** - "What is X and why is it used?"
+2. **Why Questions** - "Why do we do X instead of Y?"
+3. **Code Reading** - "What does this code do?"
+4. **Practical** - "When would you use X?"
+5. **True/False** - "True or false: X can do Y"
+6. **Connection** - "How does X relate to Y from Step N-1?"
+7. **Troubleshooting** - "What would happen if X was missing?"
+
+## Answer Quality Guidelines
+
+Each answer should include:
+- **Direct answer** first (bold)
+- **Explanation** of why
+- **Code examples** where relevant
+- **ASCII diagrams** for complex concepts
+- **Common mistakes** to avoid
+- **Connection** to the bigger picture
+
+## Example Output
+
+For Step 2 (TypeScript Config), questions might include:
+- What is a path alias and why use `@/`?
+- What does `strict: true` do in TypeScript?
+- Why is `tsconfig.json` needed for a Next.js project?
+
+Answers would explain each concept with examples from the actual files created.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,58 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+pnpm install          # Install dependencies
+pnpm dev              # Start dev server (Next.js + Turbopack) at localhost:3000
+pnpm build            # Production build
+pnpm lint             # Run ESLint
+pnpm format           # Format code with Prettier
+pnpm format:check     # Check formatting without changes
+```
+
+## Environment Setup
+
+Copy `.env.example` to `.env.local` and configure:
+- `LIVEKIT_API_KEY` / `LIVEKIT_API_SECRET` / `LIVEKIT_URL` - Required for token generation
+- `AGENT_NAME` - Optional, leave blank for automatic agent dispatch
+
+## Architecture
+
+This is a Next.js 15 + React 19 voice agent frontend for LiveKit. The app connects users to AI voice agents via real-time audio/video.
+
+### Core Data Flow
+
+1. **App** (`components/app/app.tsx`) wraps everything in LiveKit's `SessionProvider`
+2. **ViewController** switches between `WelcomeView` (pre-call) and `SessionView` (active call)
+3. On "Start call", the app fetches a token from `/api/connection-details` and joins a LiveKit room
+4. **SessionView** displays the agent video/audio tiles, chat transcript, and control bar
+
+### Key Directories
+
+- `app/api/connection-details/` - Token generation endpoint (creates room, participant identity, JWT)
+- `components/app/` - Main views: `welcome-view.tsx`, `session-view.tsx`, `tile-layout.tsx`, `chat-transcript.tsx`
+- `components/livekit/agent-control-bar/` - Microphone/camera/screen share toggles, chat input, device selection
+- `components/livekit/agent-control-bar/hooks/` - `useInputControls` (device state), `usePublishPermissions` (permission checks)
+- `hooks/` - `useAgentErrors` (failure handling), `useDebugMode` (dev logging)
+- `lib/utils.ts` - Config fetching (`getAppConfig`), styling utilities, sandbox token helpers
+- `app-config.ts` - Feature flags and branding configuration
+
+### Configuration
+
+`app-config.ts` defines `AppConfig` with:
+- UI branding: `logo`, `accent`, `pageTitle`, `companyName`
+- Feature flags: `supportsChatInput`, `supportsVideoInput`, `supportsScreenShare`
+- Agent dispatch: `agentName` for explicit dispatch
+
+Config can be fetched remotely via `NEXT_PUBLIC_APP_CONFIG_ENDPOINT` (for sandbox deployments) or uses defaults.
+
+### Tech Stack
+
+- **LiveKit**: `@livekit/components-react`, `livekit-client`, `livekit-server-sdk`
+- **Animation**: `motion` (Framer Motion)
+- **UI**: Tailwind CSS v4, Radix UI primitives, Phosphor Icons
+- **Notifications**: `sonner` toasts
+- **Theming**: `next-themes` for dark mode

--- a/Docs/PLAN.md
+++ b/Docs/PLAN.md
@@ -1,0 +1,543 @@
+# LiveKit Learning Plan
+
+A hands-on guide to understanding LiveKit by building a simple video room application.
+
+---
+
+## 1. Overview
+
+**Goal**: Build a minimal, properly-structured app to understand LiveKit fundamentals, then see how AI voice agents fit in.
+
+**Approach**: Create a separate `livekit-learning/` folder with a clean Next.js app that demonstrates core concepts step by step.
+
+**What You'll Learn**:
+- Rooms, Participants, and Tracks
+- Token-based authentication
+- Publishing and subscribing to audio/video
+- Event-driven architecture
+- How AI agents integrate as participants
+
+---
+
+## 2. Setup & Account Creation
+
+### 2.1 Create LiveKit Cloud Account (Free)
+
+1. Go to https://cloud.livekit.io
+2. Sign up for a free account (no credit card required)
+3. Create a new project
+4. From the project dashboard, copy:
+   - `LIVEKIT_API_KEY`
+   - `LIVEKIT_API_SECRET`
+   - `LIVEKIT_URL` (e.g., `wss://your-project.livekit.cloud`)
+
+### 2.2 Environment Setup
+
+Create `.env.local` in the `livekit-learning/` folder:
+
+```bash
+cp .env.example .env.local
+# Then fill in your credentials
+```
+
+---
+
+## 3. Core Concepts
+
+### 3.1 Rooms
+
+A **Room** is a virtual space where participants meet. Think of it like a video call room.
+
+- Each room has a unique name
+- Participants join by connecting to that room
+- Rooms are created automatically when the first participant joins
+
+### 3.2 Participants
+
+Anyone connected to a room is a **Participant**. There are two types:
+
+| Type | Description | Example |
+|------|-------------|---------|
+| **Local Participant** | You | Your browser session |
+| **Remote Participant** | Everyone else | Other users, AI agents |
+
+### 3.3 Tracks
+
+**Tracks** are audio or video streams.
+
+- **Publishing**: When you turn on your camera, you "publish" a video track
+- **Subscribing**: When someone else has their camera on, you "subscribe" to their track
+- Track types: `Audio`, `Video`, `Data` (for messages)
+
+### 3.4 Tokens
+
+**Tokens** are JWTs that authenticate participants.
+
+They contain:
+- **Identity**: Who you are (unique per participant)
+- **Room**: Which room you can join
+- **Permissions**: What you can do (publish video? audio? subscribe?)
+
+Tokens are signed with your API secret, so only your server can create valid tokens.
+
+### 3.5 Events
+
+LiveKit uses **events** to notify you when things happen:
+
+| Event | When it fires |
+|-------|---------------|
+| `ConnectionStateChanged` | Connection status changes |
+| `ParticipantConnected` | Someone joins the room |
+| `ParticipantDisconnected` | Someone leaves the room |
+| `TrackSubscribed` | You receive someone's track |
+| `TrackUnsubscribed` | A track is removed |
+
+---
+
+## 4. Architecture
+
+### 4.1 System Overview
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                      LiveKit Cloud                          │
+│  ┌─────────────────────────────────────────────────────┐    │
+│  │                     ROOM                            │    │
+│  │                                                     │    │
+│  │   ┌──────────┐    Tracks    ┌──────────┐           │    │
+│  │   │  You     │ ──────────▶  │  Others  │           │    │
+│  │   │ (Local)  │ ◀──────────  │ (Remote) │           │    │
+│  │   └──────────┘              └──────────┘           │    │
+│  │        │                          │                │    │
+│  │        └──────────────────────────┘                │    │
+│  │                    │                               │    │
+│  └────────────────────┼───────────────────────────────┘    │
+│                       │ WebSocket                          │
+└───────────────────────┼─────────────────────────────────────┘
+                        │
+        ┌───────────────┴───────────────┐
+        │                               │
+┌───────▼───────┐               ┌───────▼───────┐
+│  Your Browser │               │  AI Agent     │
+│  (livekit-    │               │  (Python/     │
+│   client)     │               │   Node.js)    │
+└───────────────┘               └───────────────┘
+```
+
+### 4.2 Token Flow
+
+```
+Browser                    Your Server                LiveKit Cloud
+   │                            │                           │
+   │  1. Request token          │                           │
+   │ ─────────────────────────▶ │                           │
+   │                            │                           │
+   │  2. Generate JWT with      │                           │
+   │     identity + room +      │                           │
+   │     permissions            │                           │
+   │ ◀───────────────────────── │                           │
+   │                            │                           │
+   │  3. Connect with token     │                           │
+   │ ──────────────────────────────────────────────────────▶│
+   │                            │                           │
+   │  4. Validate token,        │                           │
+   │     join room              │                           │
+   │ ◀──────────────────────────────────────────────────────│
+```
+
+---
+
+## 5. Project Structure
+
+```
+livekit-learning/
+├── app/
+│   ├── api/
+│   │   └── token/route.ts      # Token generation endpoint
+│   ├── room/
+│   │   └── page.tsx            # Room page (client component)
+│   ├── layout.tsx              # Root layout
+│   ├── page.tsx                # Home page with concept explanations
+│   └── globals.css             # Styles
+├── components/
+│   ├── VideoTile.tsx           # Display a video track
+│   └── ConnectionStatus.tsx    # Show connection state
+├── .env.local                  # Your credentials (not committed)
+├── .env.example                # Template for credentials
+└── package.json                # Dependencies
+```
+
+---
+
+## 6. Implementation Details
+
+### 6.1 Token Generation (`app/api/token/route.ts`)
+
+```typescript
+const token = new AccessToken(apiKey, apiSecret, {
+  identity: userName,  // Who this person is
+  ttl: '1h',           // Token expires in 1 hour
+});
+
+token.addGrant({
+  room: roomName,      // Which room they can join
+  roomJoin: true,      // Can join the room
+  canPublish: true,    // Can publish audio/video
+  canSubscribe: true,  // Can receive others' audio/video
+});
+```
+
+### 6.2 Room Connection (`app/room/page.tsx`)
+
+```typescript
+// 1. Create room instance
+const room = new Room();
+
+// 2. Set up event listeners
+room.on(RoomEvent.ParticipantConnected, (participant) => {
+  console.log('Someone joined:', participant.identity);
+});
+
+// 3. Connect with token
+await room.connect(url, token);
+
+// 4. Enable camera
+await room.localParticipant.setCameraEnabled(true);
+```
+
+### 6.3 Displaying Video
+
+```typescript
+// Attach a video track to a <video> element
+const videoElement = document.getElementById('video');
+videoTrack.attach(videoElement);
+```
+
+---
+
+## 7. Agent Integration
+
+### 7.1 How Agents Work
+
+AI agents are simply **participants that connect to the room** programmatically. Instead of a human controlling them, code controls them.
+
+The agent:
+1. Connects to the same room as users
+2. Subscribes to users' audio tracks
+3. Processes audio through AI pipeline
+4. Publishes audio/video responses back
+
+### 7.2 Agent Flow
+
+```
+User speaks
+    ↓
+Audio track published to room
+    ↓
+Agent subscribes to your audio
+    ↓
+Speech-to-Text (STT)
+    ↓
+Large Language Model (LLM)
+    ↓
+Text-to-Speech (TTS)
+    ↓
+Agent publishes audio track
+    ↓
+You hear the response
+```
+
+### 7.3 Agent Dispatch
+
+When a user joins a room, an agent can be automatically dispatched to join the same room. This is handled by:
+
+1. **Explicit dispatch**: Your server tells LiveKit to start an agent for a specific room
+2. **Automatic dispatch**: Configure LiveKit to auto-dispatch agents when rooms are created
+
+The `douala` app in this repo demonstrates agent dispatch via the `AGENT_NAME` environment variable.
+
+---
+
+## 8. Verification Plan
+
+| Step | Test | Expected Result |
+|------|------|-----------------|
+| 1 | Visit `/api/token?room=test&user=alice` | JSON with `token` and `url` |
+| 2 | Open `/room?name=test` | "Connected" status |
+| 3 | Click "Enable Camera" | See your video |
+| 4 | Open same room in 2 tabs | See each other's video |
+| 5 | Check event log | See connection/track events |
+
+---
+
+## 9. Files Created
+
+| File | Purpose | Status |
+|------|---------|--------|
+| `livekit-learning/package.json` | Dependencies | ✅ Created |
+| `livekit-learning/app/layout.tsx` | Root layout | ✅ Created |
+| `livekit-learning/app/globals.css` | Styles | ❌ Not created |
+| `livekit-learning/app/page.tsx` | Home with explanations | ✅ Created |
+| `livekit-learning/app/api/token/route.ts` | Token generation | ✅ Created |
+| `livekit-learning/app/room/page.tsx` | Room interface | ✅ Created |
+| `livekit-learning/components/VideoTile.tsx` | Video display | ❌ Not created |
+| `livekit-learning/components/ConnectionStatus.tsx` | Connection indicator | ❌ Not created |
+| `livekit-learning/.env.example` | Credential template | ✅ Created |
+| `livekit-learning/tsconfig.json` | TypeScript config | ❌ Not created |
+| `livekit-learning/next.config.ts` | Next.js config | ❌ Not created |
+
+---
+
+## 10. Step-by-Step Learning Journey
+
+Work through these steps in order. After each step, take time to understand what was done and why before moving on.
+
+---
+
+### Phase A: Project Setup
+
+#### Step 1: Create project structure with package.json
+- [x] **Status**: ✅ Completed
+- **What we're doing**: Setting up a new Next.js project with LiveKit dependencies
+- **Files**: `livekit-learning/package.json`
+- **What you'll learn**:
+  - The two main LiveKit packages: `livekit-client` (browser) and `livekit-server-sdk` (server)
+  - Why we need both: client connects to rooms, server generates tokens
+- **Review after completing**:
+  - Open `package.json` and look at the dependencies
+  - Notice `livekit-client` vs `livekit-server-sdk` - what's the difference?
+
+#### Step 2: Create TypeScript and Next.js config files
+- [ ] **Status**: Not started
+- **What we're doing**: Configuring TypeScript and Next.js for our project
+- **Files**: `tsconfig.json`, `next.config.ts`
+- **What you'll learn**:
+  - Path aliases (`@/` prefix) for cleaner imports
+  - Next.js configuration basics
+- **Review after completing**:
+  - Look at the `paths` in `tsconfig.json` - how does `@/components` work?
+
+#### Step 3: Create layout and global styles
+- [ ] **Status**: Not started
+- **What we're doing**: Setting up the root layout and CSS
+- **Files**: `app/layout.tsx`, `app/globals.css`
+- **What you'll learn**:
+  - Next.js App Router layout system
+  - How layouts wrap all pages
+- **Review after completing**:
+  - Notice how `layout.tsx` wraps `{children}` - every page gets this wrapper
+
+---
+
+### Phase B: Token Authentication
+
+#### Step 4: Create the token generation endpoint
+- [ ] **Status**: Not started
+- **What we're doing**: Building an API route that creates JWT tokens for LiveKit
+- **Files**: `app/api/token/route.ts`
+- **What you'll learn**:
+  - **JWT tokens**: How LiveKit authenticates users
+  - **AccessToken class**: The main class from `livekit-server-sdk`
+  - **Grants**: Permissions embedded in the token (canPublish, canSubscribe, etc.)
+  - **Why server-side**: Tokens must be created on the server because they're signed with your secret key
+- **Key code to understand**:
+  ```typescript
+  const token = new AccessToken(apiKey, apiSecret, { identity: userName });
+  token.addGrant({ room: roomName, roomJoin: true, canPublish: true });
+  ```
+- **Review after completing**:
+  - Read through the comments in the file
+  - What happens if you change `canPublish: false`? (User can't share camera/mic)
+  - Why do we never cache tokens? (Security - each should be fresh)
+
+#### Step 5: Create .env.local with your LiveKit credentials
+- [ ] **Status**: Not started
+- **What we're doing**: Adding your personal LiveKit Cloud credentials
+- **Files**: `.env.local` (copy from `.env.example`)
+- **What you'll learn**:
+  - How environment variables protect secrets
+  - The three required LiveKit credentials and what each does
+- **Action required**:
+  1. Go to https://cloud.livekit.io and create a free account
+  2. Create a new project
+  3. Copy API Key, API Secret, and WebSocket URL
+- **Review after completing**:
+  - `LIVEKIT_API_KEY`: Identifies your project (like a username)
+  - `LIVEKIT_API_SECRET`: Signs tokens (like a password - never expose!)
+  - `LIVEKIT_URL`: WebSocket endpoint for real-time communication
+
+#### Step 6: Test the token endpoint
+- [ ] **Status**: Not started
+- **What we're doing**: Verifying token generation works
+- **Test**: Visit `http://localhost:3001/api/token?room=test&user=alice`
+- **What you'll learn**:
+  - What a LiveKit token looks like (it's a JWT - three base64 parts separated by dots)
+  - The debug info shows what's encoded in the token
+- **Expected result**: JSON with `token`, `url`, and `_debug` fields
+- **Review after completing**:
+  - Copy the token and paste it at https://jwt.io - what do you see?
+  - The payload shows identity, room, and permissions
+
+---
+
+### Phase C: UI Components
+
+#### Step 7: Create ConnectionStatus component
+- [ ] **Status**: Not started
+- **What we're doing**: Building a visual indicator for connection state
+- **Files**: `components/ConnectionStatus.tsx`
+- **What you'll learn**:
+  - LiveKit's `ConnectionState` enum: `Disconnected`, `Connecting`, `Connected`, `Reconnecting`
+  - How to give users feedback about connection health
+- **Review after completing**:
+  - What states can a room connection be in?
+  - Why is "Reconnecting" important? (Network hiccups shouldn't break the call)
+
+#### Step 8: Create VideoTile component
+- [ ] **Status**: Not started
+- **What we're doing**: Building a component that displays a video track
+- **Files**: `components/VideoTile.tsx`
+- **What you'll learn**:
+  - **Track attachment**: How LiveKit video tracks connect to HTML `<video>` elements
+  - **The attach/detach pattern**: `track.attach(videoElement)` and `track.detach()`
+  - **useEffect cleanup**: Why we detach tracks when component unmounts
+- **Key code to understand**:
+  ```typescript
+  useEffect(() => {
+    if (track && videoRef.current) {
+      track.attach(videoRef.current);  // Connect track to <video>
+      return () => { track.detach(); }; // Cleanup on unmount
+    }
+  }, [track]);
+  ```
+- **Review after completing**:
+  - Why do we use `useRef` for the video element?
+  - What happens if we don't call `track.detach()` on cleanup?
+
+---
+
+### Phase D: Room Connection
+
+#### Step 9: Create the home page with concept explanations
+- [ ] **Status**: Not started
+- **What we're doing**: Building an educational landing page
+- **Files**: `app/page.tsx`
+- **What you'll learn**:
+  - Overview of all LiveKit concepts in one place
+  - Architecture diagrams showing how pieces connect
+- **Review after completing**:
+  - Read through each concept section
+  - Make sure you understand Rooms, Participants, Tracks, Tokens, Events
+
+#### Step 10: Create the room page (main interface)
+- [ ] **Status**: Not started
+- **What we're doing**: Building the core page where LiveKit magic happens
+- **Files**: `app/room/page.tsx`
+- **What you'll learn**:
+  - **Room class**: The main LiveKit object (`new Room()`)
+  - **Connecting**: `room.connect(url, token)`
+  - **Event listeners**: `room.on(RoomEvent.ParticipantConnected, ...)`
+  - **Local participant**: `room.localParticipant` (you)
+  - **Remote participants**: `room.remoteParticipants` (others)
+  - **Publishing tracks**: `localParticipant.setCameraEnabled(true)`
+- **Key code to understand**:
+  ```typescript
+  // 1. Create room
+  const room = new Room();
+
+  // 2. Listen for events BEFORE connecting
+  room.on(RoomEvent.ParticipantConnected, (p) => { ... });
+
+  // 3. Connect
+  await room.connect(url, token);
+
+  // 4. Publish your camera
+  await room.localParticipant.setCameraEnabled(true);
+  ```
+- **Review after completing**:
+  - Why do we set up event listeners BEFORE calling `connect()`?
+  - What's the difference between `localParticipant` and `remoteParticipants`?
+  - Look at the event log - what events fire when you connect?
+
+---
+
+### Phase E: Testing & Verification
+
+#### Step 11: Install dependencies and start the app
+- [ ] **Status**: Not started
+- **What we're doing**: Installing packages and running the dev server
+- **Commands**:
+  ```bash
+  cd livekit-learning
+  pnpm install
+  pnpm dev
+  ```
+- **What you'll learn**:
+  - The app runs on port 3001 (to avoid conflict with main app on 3000)
+- **Expected result**: App running at http://localhost:3001
+
+#### Step 12: Test single-user room connection
+- [ ] **Status**: Not started
+- **What we're doing**: Verifying you can connect to a room and see your own video
+- **Test steps**:
+  1. Go to http://localhost:3001
+  2. Click "Join Test Room"
+  3. Click "Connect"
+  4. Click "Enable Camera"
+- **What you'll learn**:
+  - The full flow: token fetch → room connect → publish camera
+  - Watch the Event Log to see what happens at each step
+- **Review after completing**:
+  - What events appeared in the log?
+  - Can you see your video in the "You" tile?
+
+#### Step 13: Test multi-participant
+- [ ] **Status**: Not started
+- **What we're doing**: Verifying two users can see each other
+- **Test steps**:
+  1. Open http://localhost:3001/room?name=test in Tab 1
+  2. Open http://localhost:3001/room?name=test in Tab 2 (same room!)
+  3. Connect both tabs
+  4. Enable camera in both tabs
+- **What you'll learn**:
+  - `ParticipantConnected` event fires when the other tab joins
+  - `TrackSubscribed` event fires when you receive their video
+  - Both tabs see each other because they're in the same room
+- **Review after completing**:
+  - What events did you see when the second tab connected?
+  - How did the first tab know about the second tab's camera?
+
+---
+
+### Phase F: Understanding the Main App
+
+#### Step 14: Review the douala app's agent integration
+- [ ] **Status**: Not started
+- **What we're doing**: Understanding how the production app integrates AI agents
+- **Files to review**:
+  - `douala/app/api/connection-details/route.ts` - Token generation with agent dispatch
+  - `douala/components/app/app.tsx` - SessionProvider setup
+  - `douala/components/app/session-view.tsx` - Active call UI
+- **What you'll learn**:
+  - How `agentName` parameter triggers agent dispatch
+  - How `@livekit/components-react` simplifies LiveKit integration
+  - The difference between our learning app (raw SDK) and production app (React components)
+- **Review after completing**:
+  - Compare our `token/route.ts` with douala's `connection-details/route.ts`
+  - What extra features does the production app have?
+  - How does the agent know to join the room?
+
+---
+
+## Progress Tracker
+
+| Phase | Steps | Status |
+|-------|-------|--------|
+| A. Project Setup | 1-3 | 🔄 In progress (1/3) |
+| B. Token Authentication | 4-6 | ⬜ Not started |
+| C. UI Components | 7-8 | ⬜ Not started |
+| D. Room Connection | 9-10 | ⬜ Not started |
+| E. Testing | 11-13 | ⬜ Not started |
+| F. Main App Review | 14 | ⬜ Not started |
+
+**Legend**: ⬜ Not started | 🔄 In progress | ✅ Completed

--- a/livekit-learning/.env.example
+++ b/livekit-learning/.env.example
@@ -1,0 +1,11 @@
+# LiveKit Credentials
+# Get these from https://cloud.livekit.io (free account)
+#
+# 1. Sign up at https://cloud.livekit.io
+# 2. Create a new project
+# 3. Go to Settings > Keys
+# 4. Copy the API Key, API Secret, and WebSocket URL
+
+LIVEKIT_API_KEY=your_api_key_here
+LIVEKIT_API_SECRET=your_api_secret_here
+LIVEKIT_URL=wss://your-project.livekit.cloud

--- a/livekit-learning/Quiz/README.md
+++ b/livekit-learning/Quiz/README.md
@@ -1,0 +1,57 @@
+# LiveKit Learning Quiz
+
+This folder contains quizzes for each step of the learning journey. Use these to test and reinforce your understanding.
+
+## How to Use
+
+1. **Complete a step** from the main `../Docs/PLAN.md`
+2. **Open the Questions file** for that step (e.g., `Step-01-Questions.md`)
+3. **Answer the questions** without looking at the answers
+4. **Check your understanding** by reading the Answers file (e.g., `Step-01-Answers.md`)
+5. **Review any concepts** you got wrong before moving to the next step
+
+## Quiz Files
+
+| Step | Topic | Questions | Answers |
+|------|-------|-----------|---------|
+| 1 | Project Structure & package.json | [Questions](Step-01-Questions.md) | [Answers](Step-01-Answers.md) |
+| 2 | TypeScript & Next.js Config | Coming soon | Coming soon |
+| 3 | Layout & Global Styles | Coming soon | Coming soon |
+| 4 | Token Generation Endpoint | Coming soon | Coming soon |
+| 5 | Environment Variables | Coming soon | Coming soon |
+| 6 | Testing Token Endpoint | Coming soon | Coming soon |
+| 7 | ConnectionStatus Component | Coming soon | Coming soon |
+| 8 | VideoTile Component | Coming soon | Coming soon |
+| 9 | Home Page | Coming soon | Coming soon |
+| 10 | Room Page | Coming soon | Coming soon |
+| 11 | Install & Run | Coming soon | Coming soon |
+| 12 | Single-User Test | Coming soon | Coming soon |
+| 13 | Multi-Participant Test | Coming soon | Coming soon |
+| 14 | Agent Integration Review | Coming soon | Coming soon |
+
+## Tips for Learning
+
+- **Don't peek at answers first** - Struggling to recall information strengthens memory
+- **Write out your answers** - Don't just think them, actually write them down
+- **Explain out loud** - If you can teach it, you understand it
+- **Review wrong answers** - These are your biggest learning opportunities
+- **Take breaks** - Spaced repetition is more effective than cramming
+
+## Progress Tracking
+
+After completing each quiz, update your progress:
+
+- [ ] Step 1: Project Structure
+- [ ] Step 2: TypeScript Config
+- [ ] Step 3: Layout & Styles
+- [ ] Step 4: Token Endpoint
+- [ ] Step 5: Environment Setup
+- [ ] Step 6: Token Testing
+- [ ] Step 7: ConnectionStatus
+- [ ] Step 8: VideoTile
+- [ ] Step 9: Home Page
+- [ ] Step 10: Room Page
+- [ ] Step 11: Install & Run
+- [ ] Step 12: Single-User Test
+- [ ] Step 13: Multi-Participant
+- [ ] Step 14: Agent Integration

--- a/livekit-learning/Quiz/Step-01-Answers.md
+++ b/livekit-learning/Quiz/Step-01-Answers.md
@@ -1,0 +1,251 @@
+# Step 1 Answers: Project Structure & Package.json
+
+Detailed explanations for each question.
+
+---
+
+## Answer 1: The Two Packages
+
+### `livekit-client`
+- **Runs on**: Browser (client-side)
+- **Used for**:
+  - Connecting to LiveKit rooms
+  - Publishing audio/video tracks (your camera, microphone)
+  - Subscribing to other participants' tracks
+  - Handling real-time events (someone joined, track published, etc.)
+
+### `livekit-server-sdk`
+- **Runs on**: Server (Node.js, in our case Next.js API routes)
+- **Used for**:
+  - Generating JWT access tokens
+  - Managing rooms programmatically (create, delete, list)
+  - Managing participants (kick, mute, etc.)
+  - Webhook handling
+
+### Why This Matters
+```
+┌─────────────────────────────────────────────┐
+│              Your Application               │
+│                                             │
+│  Browser (React)      Server (Next.js API)  │
+│  ┌─────────────┐      ┌─────────────────┐   │
+│  │ livekit-    │      │ livekit-server- │   │
+│  │ client      │      │ sdk             │   │
+│  │             │      │                 │   │
+│  │ - Connect   │      │ - Generate      │   │
+│  │ - Publish   │      │   tokens        │   │
+│  │ - Subscribe │      │ - Manage rooms  │   │
+│  └─────────────┘      └─────────────────┘   │
+└─────────────────────────────────────────────┘
+```
+
+---
+
+## Answer 2: Why Two Packages?
+
+**Short answer**: Security and separation of concerns.
+
+**Detailed explanation**:
+
+1. **Security**: The server SDK needs your `LIVEKIT_API_SECRET` to sign tokens. This secret must NEVER be exposed to browsers. By having a separate server package, you're forced to keep secret operations on the server.
+
+2. **Different environments**: Browsers and servers have different capabilities:
+   - Browsers have WebRTC for audio/video
+   - Servers have access to environment variables and secure storage
+
+3. **Bundle size**: The client package is optimized for browsers (smaller, no Node.js dependencies). Including server code would bloat the browser bundle.
+
+4. **Different use cases**:
+   - Client: Real-time communication (needs WebRTC, media handling)
+   - Server: Administrative tasks (tokens, room management)
+
+**Analogy**: Think of it like a hotel:
+- The **client SDK** is like the guest - they can enter rooms, use facilities, interact with others
+- The **server SDK** is like the hotel management - they issue key cards (tokens), create/delete rooms, control access
+
+---
+
+## Answer 3: Security Risk
+
+### a) What would we expose?
+- `LIVEKIT_API_KEY` - Your project identifier
+- `LIVEKIT_API_SECRET` - The secret key used to sign tokens
+
+### b) What could a malicious user do?
+With the API secret, an attacker could:
+1. **Create tokens for any room** - Access rooms they shouldn't be in
+2. **Create tokens with any identity** - Impersonate other users
+3. **Create tokens with admin permissions** - Grant themselves abilities to kick others, record, etc.
+4. **Create unlimited tokens** - Abuse your LiveKit quota
+5. **Access your LiveKit dashboard** - Potentially delete rooms, access recordings
+
+### c) Why is this a security problem?
+Your API secret is like a master key. Anyone with it has full control over your LiveKit project. Browser code is **always visible** to users (View Source, DevTools). There's no way to hide secrets in client-side code.
+
+**The Rule**: Never put secrets in browser code. Always keep them on the server.
+
+```
+❌ WRONG (Browser)                    ✅ CORRECT (Server)
+┌─────────────────────┐              ┌─────────────────────┐
+│ const token = new   │              │ // API Route        │
+│   AccessToken(      │              │ const token = new   │
+│     "api_key",      │              │   AccessToken(      │
+│     "SECRET123"  ←──┼── Exposed!   │     process.env.KEY,│
+│   );                │              │     process.env.SEC │
+└─────────────────────┘              │   );           ↑    │
+                                     └───────────────┼────┘
+                                              Hidden on server
+```
+
+---
+
+## Answer 4: The Token Flow
+
+**Correct order**:
+
+1. **Browser requests a token from the server**
+   - Browser calls `/api/token?room=myroom&user=alice`
+
+2. **Server creates a signed JWT token using the API secret**
+   - Server uses `AccessToken` class with the secret
+   - Token contains: identity, room name, permissions, expiry
+
+3. **Browser connects to LiveKit Cloud using the token**
+   - Browser calls `room.connect(url, token)`
+   - LiveKit Cloud validates the token signature
+   - If valid, user joins the room
+
+```
+Browser                    Server                     LiveKit Cloud
+   │                          │                            │
+   │ 1. GET /api/token        │                            │
+   │ ────────────────────────▶│                            │
+   │                          │                            │
+   │ 2. Return JWT token      │                            │
+   │ ◀────────────────────────│                            │
+   │                          │                            │
+   │ 3. Connect with token    │                            │
+   │ ─────────────────────────────────────────────────────▶│
+   │                          │                            │
+   │ 4. Validate & join       │                            │
+   │ ◀─────────────────────────────────────────────────────│
+```
+
+---
+
+## Answer 5: Port Number
+
+### a) What port?
+**Port 3001**
+
+### b) Why not 3000?
+The main application (`douala`) runs on port 3000 (the default Next.js port). If we also used 3000, we'd get a "port already in use" error.
+
+By using 3001, we can run both apps simultaneously:
+- `http://localhost:3000` → Main douala app
+- `http://localhost:3001` → Our learning app
+
+**This is a common pattern** when developing multiple related applications locally.
+
+---
+
+## Answer 6: Dependencies vs DevDependencies
+
+### a) What's the difference?
+
+| `dependencies` | `devDependencies` |
+|----------------|-------------------|
+| Required at runtime | Only needed during development |
+| Included in production build | NOT included in production |
+| Your app breaks without them | Your app runs fine without them |
+
+### b) Why is TypeScript in devDependencies?
+
+TypeScript is only used during **development** to:
+- Type-check your code
+- Compile `.ts` files to `.js`
+
+At runtime, the browser/server only runs **JavaScript** (the compiled output). TypeScript itself is never executed in production.
+
+```
+Development                          Production
+┌─────────────┐                     ┌─────────────┐
+│ app.ts      │   tsc compile       │ app.js      │
+│ (TypeScript)│ ──────────────────▶ │ (JavaScript)│
+└─────────────┘                     └─────────────┘
+   ↑                                      ↑
+TypeScript needed here            TypeScript NOT needed here
+```
+
+Similarly, `@types/*` packages provide type definitions for development but aren't needed at runtime.
+
+---
+
+## Answer 7: True or False
+
+### 1. "The `livekit-client` package can generate authentication tokens."
+**FALSE**
+
+`livekit-client` is for **using** tokens, not creating them. Token generation requires the API secret, which only the server should have. The client package connects to rooms using tokens created by the server.
+
+### 2. "Tokens contain information about which room a user can join."
+**TRUE**
+
+A LiveKit token includes a "grant" that specifies:
+- Which room the token is valid for (`room: "my-room"`)
+- Whether the user can join (`roomJoin: true`)
+- What permissions they have (`canPublish`, `canSubscribe`, etc.)
+
+You can see this by decoding a token at https://jwt.io
+
+### 3. "The browser needs the `LIVEKIT_API_SECRET` to connect to a room."
+**FALSE**
+
+The browser only needs:
+- The **token** (which was signed with the secret on the server)
+- The **LiveKit server URL** (`wss://your-project.livekit.cloud`)
+
+The secret stays on your server. The token proves the user was authorized by your server without exposing the secret.
+
+---
+
+## Bonus Answer
+
+**Neither `livekit-client` nor `livekit-server-sdk`** - you would use:
+- **iOS**: `livekit-swift` (Swift SDK)
+- **Android**: `livekit-android` (Kotlin SDK)
+
+LiveKit provides native SDKs for each platform:
+- `livekit-client` → JavaScript/TypeScript (Web browsers)
+- `livekit-swift` → iOS/macOS
+- `livekit-android` → Android
+- `livekit-flutter` → Flutter (cross-platform)
+- `livekit-react-native` → React Native
+
+However, you would still use `livekit-server-sdk` (or equivalent) on your **backend** to generate tokens. The server-side token generation is the same regardless of which client platform you're using.
+
+```
+                    Your Server
+                    (livekit-server-sdk)
+                          │
+                          │ Generates tokens for all clients
+                          │
+        ┌─────────────────┼─────────────────┐
+        │                 │                 │
+        ▼                 ▼                 ▼
+   Web Browser       iOS App          Android App
+  (livekit-client)  (livekit-swift)  (livekit-android)
+```
+
+---
+
+## Summary: Key Takeaways from Step 1
+
+1. **Two packages, two purposes**: `livekit-client` for browsers, `livekit-server-sdk` for servers
+2. **Tokens are server-side only**: Never expose your API secret to the browser
+3. **The flow**: Browser → requests token → Server creates token → Browser connects with token
+4. **Security first**: The separation exists primarily for security reasons
+
+---
+
+**Ready for Step 2? Move on to create the TypeScript and Next.js config files!**

--- a/livekit-learning/Quiz/Step-01-Questions.md
+++ b/livekit-learning/Quiz/Step-01-Questions.md
@@ -1,0 +1,96 @@
+# Step 1 Quiz: Project Structure & Package.json
+
+Test your understanding of LiveKit package basics before moving to Step 2.
+
+---
+
+## Question 1: The Two Packages
+
+What are the **two main LiveKit packages** we added to `package.json`?
+
+For each package, state:
+- a) The package name
+- b) Where it runs (browser or server)
+- c) What it's used for
+
+---
+
+## Question 2: Why Two Packages?
+
+Why does LiveKit have **two separate packages** instead of combining everything into one?
+
+---
+
+## Question 3: Security Risk
+
+Imagine we tried to generate tokens directly in the browser (client-side) instead of on the server.
+
+- a) What information would we need to expose to the browser?
+- b) What could a malicious user do with that information?
+- c) Why is this a security problem?
+
+---
+
+## Question 4: The Token Flow
+
+Put these steps in the **correct order** (1, 2, 3):
+
+- [ ] Browser connects to LiveKit Cloud using the token
+- [ ] Server creates a signed JWT token using the API secret
+- [ ] Browser requests a token from the server
+
+---
+
+## Question 5: Port Number
+
+Looking at the `scripts` section in `package.json`:
+
+```json
+"scripts": {
+  "dev": "next dev --turbopack -p 3001"
+}
+```
+
+- a) What port will the app run on?
+- b) Why did we choose this port instead of the default (3000)?
+
+---
+
+## Question 6: Dependencies vs DevDependencies
+
+In `package.json`, we have both `dependencies` and `devDependencies`:
+
+```json
+"dependencies": {
+  "livekit-client": "^2.15.15",
+  "livekit-server-sdk": "^2.13.2",
+  ...
+},
+"devDependencies": {
+  "@types/node": "^22.0.0",
+  "typescript": "^5"
+}
+```
+
+- a) What's the difference between `dependencies` and `devDependencies`?
+- b) Why is `typescript` in `devDependencies` and not `dependencies`?
+
+---
+
+## Question 7: Conceptual Understanding
+
+True or False (and explain why):
+
+1. "The `livekit-client` package can generate authentication tokens."
+2. "Tokens contain information about which room a user can join."
+3. "The browser needs the `LIVEKIT_API_SECRET` to connect to a room."
+
+---
+
+## Bonus Question
+
+If you wanted to create a mobile app (iOS/Android) that connects to LiveKit, would you use `livekit-client` or `livekit-server-sdk`? Why?
+
+---
+
+**When you're done, check your answers in `Step-01-Answers.md`**

--- a/livekit-learning/app/api/token/route.ts
+++ b/livekit-learning/app/api/token/route.ts
@@ -1,0 +1,120 @@
+import { AccessToken } from 'livekit-server-sdk';
+import { NextRequest, NextResponse } from 'next/server';
+
+/**
+ * TOKEN GENERATION ENDPOINT
+ *
+ * This endpoint creates JWT tokens that allow clients to connect to LiveKit rooms.
+ *
+ * Key concepts:
+ * 1. AccessToken - The main class from livekit-server-sdk that creates tokens
+ * 2. Identity - A unique identifier for the participant (like a username)
+ * 3. Room grants - Permissions specifying which room to join and what actions are allowed
+ *
+ * The token is signed with your API secret, so only your server can create valid tokens.
+ * Clients cannot forge tokens because they don't have the secret.
+ */
+export async function GET(request: NextRequest) {
+  // Get room name and user identity from query parameters
+  const searchParams = request.nextUrl.searchParams;
+  const roomName = searchParams.get('room');
+  const userName = searchParams.get('user');
+
+  // Validate required parameters
+  if (!roomName) {
+    return NextResponse.json(
+      { error: 'Missing "room" query parameter. Example: /api/token?room=my-room&user=alice' },
+      { status: 400 }
+    );
+  }
+
+  if (!userName) {
+    return NextResponse.json(
+      { error: 'Missing "user" query parameter. Example: /api/token?room=my-room&user=alice' },
+      { status: 400 }
+    );
+  }
+
+  // Check environment variables
+  const apiKey = process.env.LIVEKIT_API_KEY;
+  const apiSecret = process.env.LIVEKIT_API_SECRET;
+  const livekitUrl = process.env.LIVEKIT_URL;
+
+  if (!apiKey || !apiSecret || !livekitUrl) {
+    return NextResponse.json(
+      {
+        error: 'Missing LiveKit credentials. Please set LIVEKIT_API_KEY, LIVEKIT_API_SECRET, and LIVEKIT_URL in .env.local',
+        hint: 'Get free credentials at https://cloud.livekit.io',
+      },
+      { status: 500 }
+    );
+  }
+
+  try {
+    // Create an access token
+    // The token is signed with your API secret, making it impossible to forge
+    const token = new AccessToken(apiKey, apiSecret, {
+      // Identity is how this participant will be identified in the room
+      // Other participants will see this identity
+      identity: userName,
+
+      // Optional: Human-readable name (can be different from identity)
+      name: userName,
+
+      // Token expires after 1 hour
+      // After expiration, the client will be disconnected
+      ttl: '1h',
+    });
+
+    // Add room grant - this specifies what the token holder can do
+    token.addGrant({
+      // Which room this token is valid for
+      room: roomName,
+
+      // Can join the room?
+      roomJoin: true,
+
+      // Can publish audio? (microphone)
+      canPublish: true,
+
+      // Can publish data messages? (for chat, etc.)
+      canPublishData: true,
+
+      // Can subscribe to other participants' tracks?
+      canSubscribe: true,
+    });
+
+    // Generate the JWT string
+    const jwt = await token.toJwt();
+
+    // Return the token and server URL
+    return NextResponse.json(
+      {
+        token: jwt,
+        url: livekitUrl,
+
+        // Include some debug info
+        _debug: {
+          room: roomName,
+          identity: userName,
+          expiresIn: '1 hour',
+          permissions: {
+            canPublish: true,
+            canPublishData: true,
+            canSubscribe: true,
+          },
+        },
+      },
+      {
+        // Never cache tokens - they should be generated fresh each time
+        headers: { 'Cache-Control': 'no-store' },
+      }
+    );
+  } catch (error) {
+    console.error('Error generating token:', error);
+    return NextResponse.json(
+      { error: 'Failed to generate token', details: String(error) },
+      { status: 500 }
+    );
+  }
+}

--- a/livekit-learning/app/globals.css
+++ b/livekit-learning/app/globals.css
@@ -1,0 +1,176 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+:root {
+  --background: #ffffff;
+  --foreground: #171717;
+  --muted: #737373;
+  --border: #e5e5e5;
+  --accent: #0066ff;
+  --success: #22c55e;
+  --warning: #f59e0b;
+  --error: #ef4444;
+}
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: var(--background);
+  color: var(--foreground);
+  line-height: 1.6;
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+code {
+  font-family: ui-monospace, monospace;
+  background: #f5f5f5;
+  padding: 0.2em 0.4em;
+  border-radius: 4px;
+  font-size: 0.9em;
+}
+
+pre {
+  background: #1e1e1e;
+  color: #d4d4d4;
+  padding: 1rem;
+  border-radius: 8px;
+  overflow-x: auto;
+}
+
+pre code {
+  background: none;
+  padding: 0;
+}
+
+.container {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.card {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1.5rem;
+  margin: 1rem 0;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.5rem;
+  border-radius: 8px;
+  font-weight: 500;
+  cursor: pointer;
+  border: none;
+  transition: all 0.15s;
+}
+
+.button-primary {
+  background: var(--accent);
+  color: white;
+}
+
+.button-primary:hover {
+  background: #0052cc;
+}
+
+.button-secondary {
+  background: #f5f5f5;
+  color: var(--foreground);
+}
+
+.button-secondary:hover {
+  background: #e5e5e5;
+}
+
+.button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Video styles */
+.video-container {
+  position: relative;
+  background: #000;
+  border-radius: 12px;
+  overflow: hidden;
+  aspect-ratio: 16/9;
+}
+
+.video-container video {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.video-label {
+  position: absolute;
+  bottom: 0.5rem;
+  left: 0.5rem;
+  background: rgba(0, 0, 0, 0.7);
+  color: white;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  font-size: 0.875rem;
+}
+
+/* Status badge */
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  border-radius: 9999px;
+  font-size: 0.875rem;
+  font-weight: 500;
+}
+
+.status-connected {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.status-connecting {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.status-disconnected {
+  background: #f3f4f6;
+  color: #374151;
+}
+
+/* Grid layout for videos */
+.video-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+}
+
+/* Concept cards */
+.concept {
+  border-left: 4px solid var(--accent);
+  padding-left: 1rem;
+  margin: 1.5rem 0;
+}
+
+.concept h3 {
+  margin-bottom: 0.5rem;
+}
+
+.concept p {
+  color: var(--muted);
+}

--- a/livekit-learning/app/layout.tsx
+++ b/livekit-learning/app/layout.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from 'next';
+import './globals.css';
+
+export const metadata: Metadata = {
+  title: 'LiveKit Learning',
+  description: 'Learn LiveKit fundamentals by building',
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/livekit-learning/app/page.tsx
+++ b/livekit-learning/app/page.tsx
@@ -1,0 +1,182 @@
+import Link from 'next/link';
+
+export default function Home() {
+  return (
+    <div className="container">
+      <h1>LiveKit Learning</h1>
+      <p style={{ color: 'var(--muted)', marginTop: '0.5rem' }}>
+        Learn LiveKit fundamentals by building a simple video room.
+      </p>
+
+      <div className="card" style={{ marginTop: '2rem', background: '#fffbeb' }}>
+        <h2>Before You Start</h2>
+        <p style={{ marginTop: '0.5rem' }}>
+          Make sure you have set up your <code>.env.local</code> file with your LiveKit credentials.
+          See <code>.env.example</code> for the required variables.
+        </p>
+        <p style={{ marginTop: '1rem' }}>
+          <strong>Need credentials?</strong> Get them free at{' '}
+          <a href="https://cloud.livekit.io" target="_blank" rel="noopener">
+            cloud.livekit.io
+          </a>
+        </p>
+      </div>
+
+      <h2 style={{ marginTop: '2rem' }}>Core Concepts</h2>
+
+      <div className="concept">
+        <h3>1. Rooms</h3>
+        <p>
+          A Room is a virtual space where participants meet. Think of it like a video call room.
+          Each room has a unique name, and participants join by connecting to that room.
+        </p>
+      </div>
+
+      <div className="concept">
+        <h3>2. Participants</h3>
+        <p>
+          Anyone connected to a room is a Participant. There are two types: the Local Participant
+          (you) and Remote Participants (everyone else, including AI agents).
+        </p>
+      </div>
+
+      <div className="concept">
+        <h3>3. Tracks</h3>
+        <p>
+          Tracks are audio or video streams. When you turn on your camera, you &quot;publish&quot;
+          a video track. When someone else has their camera on, you &quot;subscribe&quot; to their
+          track.
+        </p>
+      </div>
+
+      <div className="concept">
+        <h3>4. Tokens</h3>
+        <p>
+          Tokens are JWT (JSON Web Tokens) that authenticate you. They contain your identity (who
+          you are), the room you can join, and what permissions you have (can you publish video?
+          audio?).
+        </p>
+      </div>
+
+      <div className="concept">
+        <h3>5. Events</h3>
+        <p>
+          LiveKit uses events to notify you when things happen: someone joins, someone leaves, a
+          track is published, etc. Your app listens for these events and updates the UI
+          accordingly.
+        </p>
+      </div>
+
+      <h2 style={{ marginTop: '2rem' }}>Architecture Overview</h2>
+
+      <pre>
+        <code>{`┌─────────────────────────────────────────────────────────────┐
+│                      LiveKit Cloud                          │
+│  ┌─────────────────────────────────────────────────────┐    │
+│  │                     ROOM                            │    │
+│  │                                                     │    │
+│  │   ┌──────────┐    Tracks    ┌──────────┐           │    │
+│  │   │  You     │ ──────────▶  │  Others  │           │    │
+│  │   │ (Local)  │ ◀──────────  │ (Remote) │           │    │
+│  │   └──────────┘              └──────────┘           │    │
+│  │        │                          │                │    │
+│  │        └──────────────────────────┘                │    │
+│  │                    │                               │    │
+│  └────────────────────┼───────────────────────────────┘    │
+│                       │ WebSocket                          │
+└───────────────────────┼─────────────────────────────────────┘
+                        │
+        ┌───────────────┴───────────────┐
+        │                               │
+┌───────▼───────┐               ┌───────▼───────┐
+│  Your Browser │               │  AI Agent     │
+│  (livekit-    │               │  (Python/     │
+│   client)     │               │   Node.js)    │
+└───────────────┘               └───────────────┘`}</code>
+      </pre>
+
+      <h2 style={{ marginTop: '2rem' }}>Try It Out</h2>
+
+      <div className="card">
+        <h3>Test Token Generation</h3>
+        <p style={{ marginTop: '0.5rem' }}>
+          First, verify your credentials work by checking the token endpoint:
+        </p>
+        <p style={{ marginTop: '0.5rem' }}>
+          <code>
+            <a href="/api/token?room=test-room&user=alice" target="_blank">
+              /api/token?room=test-room&user=alice
+            </a>
+          </code>
+        </p>
+        <p style={{ marginTop: '0.5rem', color: 'var(--muted)' }}>
+          You should see a JSON response with <code>token</code> and <code>url</code>.
+        </p>
+      </div>
+
+      <div className="card">
+        <h3>Join a Room</h3>
+        <p style={{ marginTop: '0.5rem' }}>
+          Once tokens work, try joining a room:
+        </p>
+        <Link href="/room?name=my-test-room" className="button button-primary" style={{ marginTop: '1rem' }}>
+          Join Test Room →
+        </Link>
+        <p style={{ marginTop: '1rem', color: 'var(--muted)' }}>
+          Tip: Open the same room in two browser tabs to see multi-participant features.
+        </p>
+      </div>
+
+      <h2 style={{ marginTop: '2rem' }}>How Agents Fit In</h2>
+
+      <div className="concept">
+        <h3>AI Agents are Just Participants</h3>
+        <p>
+          An AI agent is simply another participant that connects to the room. The difference is
+          that instead of a human controlling it, code controls it. The agent subscribes to your
+          audio track, processes it (speech-to-text → LLM → text-to-speech), and publishes audio
+          back.
+        </p>
+      </div>
+
+      <pre>
+        <code>{`User speaks
+    ↓
+Audio track published to room
+    ↓
+Agent subscribes to your audio
+    ↓
+Speech-to-Text (STT)
+    ↓
+Large Language Model (LLM)
+    ↓
+Text-to-Speech (TTS)
+    ↓
+Agent publishes audio track
+    ↓
+You hear the response`}</code>
+      </pre>
+
+      <div className="card" style={{ marginTop: '2rem' }}>
+        <h3>Next Steps</h3>
+        <ol style={{ marginTop: '0.5rem', paddingLeft: '1.5rem' }}>
+          <li>
+            Get your credentials from{' '}
+            <a href="https://cloud.livekit.io" target="_blank" rel="noopener">
+              LiveKit Cloud
+            </a>
+          </li>
+          <li>
+            Create <code>.env.local</code> with your keys
+          </li>
+          <li>Test the token endpoint</li>
+          <li>Join a room and see your video</li>
+          <li>Open two tabs to the same room</li>
+          <li>
+            Check out the main <code>douala</code> app to see agent integration
+          </li>
+        </ol>
+      </div>
+    </div>
+  );
+}

--- a/livekit-learning/app/room/page.tsx
+++ b/livekit-learning/app/room/page.tsx
@@ -1,0 +1,417 @@
+'use client';
+
+import { useEffect, useState, useCallback, useRef } from 'react';
+import { useSearchParams } from 'next/navigation';
+import Link from 'next/link';
+import {
+  Room,
+  RoomEvent,
+  ConnectionState,
+  LocalParticipant,
+  RemoteParticipant,
+  Track,
+  VideoTrack,
+  RemoteTrack,
+  RemoteTrackPublication,
+  Participant,
+} from 'livekit-client';
+import { ConnectionStatus } from '@/components/ConnectionStatus';
+import { VideoTile } from '@/components/VideoTile';
+
+/**
+ * ROOM PAGE
+ *
+ * This is the main page where LiveKit connection and interaction happens.
+ *
+ * Flow:
+ * 1. Get room name from URL (?name=my-room)
+ * 2. Fetch token from /api/token
+ * 3. Create Room instance and connect
+ * 4. Enable camera/microphone
+ * 5. Display local and remote video tracks
+ * 6. Handle events (participants joining/leaving, tracks published/unpublished)
+ */
+
+// Generate a random user ID for this session
+function generateUserId(): string {
+  return `user-${Math.random().toString(36).substring(2, 8)}`;
+}
+
+export default function RoomPage() {
+  const searchParams = useSearchParams();
+  const roomName = searchParams.get('name') || 'default-room';
+
+  // Store userId in a ref so it persists across renders but is generated once
+  const userIdRef = useRef<string>(generateUserId());
+
+  // Room instance - the main LiveKit object
+  const [room, setRoom] = useState<Room | null>(null);
+
+  // Connection state
+  const [connectionState, setConnectionState] = useState<ConnectionState>(
+    ConnectionState.Disconnected
+  );
+
+  // Local video track (your camera)
+  const [localVideoTrack, setLocalVideoTrack] = useState<VideoTrack | null>(null);
+
+  // Remote participants and their video tracks
+  const [remoteParticipants, setRemoteParticipants] = useState<Map<string, RemoteParticipant>>(
+    new Map()
+  );
+
+  // Error state
+  const [error, setError] = useState<string | null>(null);
+
+  // Event log for learning purposes
+  const [eventLog, setEventLog] = useState<string[]>([]);
+
+  // Helper to add events to log
+  const logEvent = useCallback((message: string) => {
+    const timestamp = new Date().toLocaleTimeString();
+    setEventLog((prev) => [`[${timestamp}] ${message}`, ...prev].slice(0, 20));
+  }, []);
+
+  // Connect to the room
+  const connect = useCallback(async () => {
+    setError(null);
+    logEvent('Fetching token...');
+
+    try {
+      // Step 1: Get token from our API
+      const response = await fetch(
+        `/api/token?room=${encodeURIComponent(roomName)}&user=${encodeURIComponent(userIdRef.current)}`
+      );
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.error || 'Failed to get token');
+      }
+
+      const { token, url } = await response.json();
+      logEvent('Token received, connecting to room...');
+
+      // Step 2: Create a new Room instance
+      const newRoom = new Room({
+        // Automatically manage subscribed video quality based on size
+        adaptiveStream: true,
+
+        // Optimize for low latency
+        dynacast: true,
+      });
+
+      // Step 3: Set up event listeners BEFORE connecting
+      // This ensures we don't miss any events
+
+      // Connection state changes
+      newRoom.on(RoomEvent.ConnectionStateChanged, (state: ConnectionState) => {
+        setConnectionState(state);
+        logEvent(`Connection state: ${state}`);
+      });
+
+      // When a participant connects
+      newRoom.on(RoomEvent.ParticipantConnected, (participant: RemoteParticipant) => {
+        logEvent(`Participant joined: ${participant.identity}`);
+        setRemoteParticipants((prev) => {
+          const updated = new Map(prev);
+          updated.set(participant.identity, participant);
+          return updated;
+        });
+      });
+
+      // When a participant disconnects
+      newRoom.on(RoomEvent.ParticipantDisconnected, (participant: RemoteParticipant) => {
+        logEvent(`Participant left: ${participant.identity}`);
+        setRemoteParticipants((prev) => {
+          const updated = new Map(prev);
+          updated.delete(participant.identity);
+          return updated;
+        });
+      });
+
+      // When we subscribe to a remote track (audio/video from others)
+      newRoom.on(
+        RoomEvent.TrackSubscribed,
+        (track: RemoteTrack, publication: RemoteTrackPublication, participant: RemoteParticipant) => {
+          logEvent(`Subscribed to ${track.kind} from ${participant.identity}`);
+
+          // Force re-render to show new tracks
+          setRemoteParticipants((prev) => {
+            const updated = new Map(prev);
+            updated.set(participant.identity, participant);
+            return updated;
+          });
+
+          // Auto-play audio tracks
+          if (track.kind === Track.Kind.Audio) {
+            const audioElement = document.createElement('audio');
+            audioElement.autoplay = true;
+            track.attach(audioElement);
+          }
+        }
+      );
+
+      // When a remote track is unsubscribed
+      newRoom.on(
+        RoomEvent.TrackUnsubscribed,
+        (track: RemoteTrack, publication: RemoteTrackPublication, participant: RemoteParticipant) => {
+          logEvent(`Unsubscribed from ${track.kind} from ${participant.identity}`);
+          track.detach();
+        }
+      );
+
+      // Step 4: Connect to the room
+      await newRoom.connect(url, token);
+      logEvent('Connected to room!');
+
+      // Step 5: Get existing participants
+      newRoom.remoteParticipants.forEach((participant: RemoteParticipant) => {
+        setRemoteParticipants((prev) => {
+          const updated = new Map(prev);
+          updated.set(participant.identity, participant);
+          return updated;
+        });
+      });
+
+      setRoom(newRoom);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unknown error';
+      setError(message);
+      logEvent(`Error: ${message}`);
+    }
+  }, [roomName, logEvent]);
+
+  // Enable camera
+  const enableCamera = useCallback(async () => {
+    if (!room) return;
+
+    try {
+      logEvent('Enabling camera...');
+
+      // This publishes your camera to the room
+      await room.localParticipant.setCameraEnabled(true);
+
+      // Get the video track
+      const cameraTrack = room.localParticipant.getTrackPublication(Track.Source.Camera);
+      if (cameraTrack?.track) {
+        setLocalVideoTrack(cameraTrack.track as VideoTrack);
+        logEvent('Camera enabled');
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to enable camera';
+      logEvent(`Camera error: ${message}`);
+    }
+  }, [room, logEvent]);
+
+  // Disable camera
+  const disableCamera = useCallback(async () => {
+    if (!room) return;
+
+    logEvent('Disabling camera...');
+    await room.localParticipant.setCameraEnabled(false);
+    setLocalVideoTrack(null);
+    logEvent('Camera disabled');
+  }, [room, logEvent]);
+
+  // Enable microphone
+  const enableMicrophone = useCallback(async () => {
+    if (!room) return;
+
+    try {
+      logEvent('Enabling microphone...');
+      await room.localParticipant.setMicrophoneEnabled(true);
+      logEvent('Microphone enabled');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to enable microphone';
+      logEvent(`Microphone error: ${message}`);
+    }
+  }, [room, logEvent]);
+
+  // Disconnect from room
+  const disconnect = useCallback(async () => {
+    if (!room) return;
+
+    logEvent('Disconnecting...');
+    await room.disconnect();
+    setRoom(null);
+    setLocalVideoTrack(null);
+    setRemoteParticipants(new Map());
+    setConnectionState(ConnectionState.Disconnected);
+    logEvent('Disconnected');
+  }, [room, logEvent]);
+
+  // Clean up on unmount
+  useEffect(() => {
+    return () => {
+      if (room) {
+        room.disconnect();
+      }
+    };
+  }, [room]);
+
+  return (
+    <div className="container">
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <div>
+          <Link href="/" style={{ fontSize: '0.875rem' }}>
+            ← Back to concepts
+          </Link>
+          <h1 style={{ marginTop: '0.5rem' }}>Room: {roomName}</h1>
+          <p style={{ color: 'var(--muted)' }}>Your ID: {userIdRef.current}</p>
+        </div>
+        <ConnectionStatus state={connectionState} />
+      </div>
+
+      {error && (
+        <div
+          className="card"
+          style={{ background: '#fef2f2', borderColor: '#fecaca', marginTop: '1rem' }}
+        >
+          <strong style={{ color: '#dc2626' }}>Error:</strong> {error}
+        </div>
+      )}
+
+      {/* Controls */}
+      <div className="card" style={{ marginTop: '1rem' }}>
+        <h3>Controls</h3>
+        <div style={{ display: 'flex', gap: '0.5rem', marginTop: '0.5rem', flexWrap: 'wrap' }}>
+          {connectionState === ConnectionState.Disconnected && (
+            <button className="button button-primary" onClick={connect}>
+              Connect
+            </button>
+          )}
+
+          {connectionState === ConnectionState.Connected && (
+            <>
+              <button
+                className="button button-secondary"
+                onClick={localVideoTrack ? disableCamera : enableCamera}
+              >
+                {localVideoTrack ? 'Disable Camera' : 'Enable Camera'}
+              </button>
+              <button className="button button-secondary" onClick={enableMicrophone}>
+                Enable Microphone
+              </button>
+              <button
+                className="button"
+                style={{ background: '#fef2f2', color: '#dc2626' }}
+                onClick={disconnect}
+              >
+                Disconnect
+              </button>
+            </>
+          )}
+
+          {connectionState === ConnectionState.Connecting && (
+            <button className="button button-secondary" disabled>
+              Connecting...
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Video Grid */}
+      {connectionState === ConnectionState.Connected && (
+        <div style={{ marginTop: '1rem' }}>
+          <h3>Participants</h3>
+          <div className="video-grid" style={{ marginTop: '0.5rem' }}>
+            {/* Local video (you) */}
+            <VideoTile track={localVideoTrack} label={`You (${userIdRef.current})`} mirror />
+
+            {/* Remote participants */}
+            {Array.from(remoteParticipants.values()).map((participant) => {
+              const videoTrack = participant.getTrackPublication(Track.Source.Camera)
+                ?.track as VideoTrack | undefined;
+
+              return (
+                <VideoTile
+                  key={participant.identity}
+                  track={videoTrack || null}
+                  label={participant.identity}
+                />
+              );
+            })}
+          </div>
+
+          {remoteParticipants.size === 0 && (
+            <p style={{ color: 'var(--muted)', marginTop: '0.5rem' }}>
+              No other participants yet. Try opening this room in another tab!
+            </p>
+          )}
+        </div>
+      )}
+
+      {/* Event Log */}
+      <div className="card" style={{ marginTop: '1rem' }}>
+        <h3>Event Log</h3>
+        <p style={{ color: 'var(--muted)', fontSize: '0.875rem' }}>
+          Watch events as they happen to understand the flow.
+        </p>
+        <div
+          style={{
+            marginTop: '0.5rem',
+            maxHeight: 200,
+            overflow: 'auto',
+            fontFamily: 'monospace',
+            fontSize: '0.8rem',
+            background: '#f5f5f5',
+            padding: '0.5rem',
+            borderRadius: 4,
+          }}
+        >
+          {eventLog.length === 0 ? (
+            <div style={{ color: '#999' }}>Events will appear here...</div>
+          ) : (
+            eventLog.map((event, index) => (
+              <div key={index} style={{ padding: '2px 0' }}>
+                {event}
+              </div>
+            ))
+          )}
+        </div>
+      </div>
+
+      {/* Code Explanation */}
+      <div className="card" style={{ marginTop: '1rem' }}>
+        <h3>What&apos;s Happening in the Code</h3>
+        <div className="concept">
+          <h4>1. Token Fetch</h4>
+          <p>We call /api/token to get a JWT that grants access to the room.</p>
+        </div>
+        <div className="concept">
+          <h4>2. Room Creation</h4>
+          <p>
+            We create a <code>new Room()</code> instance - this is the main LiveKit object.
+          </p>
+        </div>
+        <div className="concept">
+          <h4>3. Event Listeners</h4>
+          <p>
+            We attach listeners for <code>RoomEvent.ParticipantConnected</code>,{' '}
+            <code>TrackSubscribed</code>, etc. before connecting.
+          </p>
+        </div>
+        <div className="concept">
+          <h4>4. Connect</h4>
+          <p>
+            <code>room.connect(url, token)</code> establishes the WebSocket connection.
+          </p>
+        </div>
+        <div className="concept">
+          <h4>5. Publish Tracks</h4>
+          <p>
+            <code>localParticipant.setCameraEnabled(true)</code> starts your camera and publishes
+            it.
+          </p>
+        </div>
+        <div className="concept">
+          <h4>6. Subscribe to Tracks</h4>
+          <p>
+            When others publish, we automatically subscribe. The <code>TrackSubscribed</code> event
+            fires.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/livekit-learning/components/ConnectionStatus.tsx
+++ b/livekit-learning/components/ConnectionStatus.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { ConnectionState } from 'livekit-client';
+
+/**
+ * CONNECTION STATUS COMPONENT
+ *
+ * Displays the current connection state of the LiveKit room.
+ *
+ * LiveKit connection states:
+ * - Disconnected: Not connected to any room
+ * - Connecting: In the process of connecting (WebSocket handshake, etc.)
+ * - Connected: Successfully connected and ready to communicate
+ * - Reconnecting: Connection lost, attempting to reconnect
+ */
+
+interface ConnectionStatusProps {
+  state: ConnectionState;
+}
+
+export function ConnectionStatus({ state }: ConnectionStatusProps) {
+  // Map connection state to display info
+  const stateInfo: Record<ConnectionState, { label: string; className: string }> = {
+    [ConnectionState.Disconnected]: {
+      label: 'Disconnected',
+      className: 'status-badge status-disconnected',
+    },
+    [ConnectionState.Connecting]: {
+      label: 'Connecting...',
+      className: 'status-badge status-connecting',
+    },
+    [ConnectionState.Connected]: {
+      label: 'Connected',
+      className: 'status-badge status-connected',
+    },
+    [ConnectionState.Reconnecting]: {
+      label: 'Reconnecting...',
+      className: 'status-badge status-connecting',
+    },
+  };
+
+  const info = stateInfo[state];
+
+  return (
+    <div className={info.className}>
+      {/* Visual indicator dot */}
+      <span
+        style={{
+          width: 8,
+          height: 8,
+          borderRadius: '50%',
+          background:
+            state === ConnectionState.Connected
+              ? '#22c55e'
+              : state === ConnectionState.Disconnected
+                ? '#9ca3af'
+                : '#f59e0b',
+        }}
+      />
+      {info.label}
+    </div>
+  );
+}

--- a/livekit-learning/components/VideoTile.tsx
+++ b/livekit-learning/components/VideoTile.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { Track, VideoTrack } from 'livekit-client';
+
+/**
+ * VIDEO TILE COMPONENT
+ *
+ * Displays a video track from a participant.
+ *
+ * Key concepts:
+ * - Tracks need to be "attached" to HTML elements to render
+ * - Video tracks attach to <video> elements
+ * - Audio tracks attach to <audio> elements (though usually you just enable them)
+ * - When a track is detached or the component unmounts, you should clean up
+ */
+
+interface VideoTileProps {
+  // The video track to display
+  track: VideoTrack | null;
+
+  // Label to show on the tile (e.g., participant name)
+  label: string;
+
+  // Mirror the video (useful for local camera)
+  mirror?: boolean;
+}
+
+export function VideoTile({ track, label, mirror = false }: VideoTileProps) {
+  // Reference to the video element
+  const videoRef = useRef<HTMLVideoElement>(null);
+
+  // Attach/detach track when it changes
+  useEffect(() => {
+    const videoElement = videoRef.current;
+    if (!videoElement) return;
+
+    if (track) {
+      // Attach the track to the video element
+      // This starts rendering the video stream
+      track.attach(videoElement);
+
+      return () => {
+        // Clean up: detach when component unmounts or track changes
+        track.detach(videoElement);
+      };
+    }
+  }, [track]);
+
+  return (
+    <div className="video-container">
+      {track ? (
+        <video
+          ref={videoRef}
+          autoPlay
+          playsInline
+          muted // Local video should always be muted to prevent echo
+          style={{
+            transform: mirror ? 'scaleX(-1)' : undefined,
+          }}
+        />
+      ) : (
+        // Placeholder when no video
+        <div
+          style={{
+            width: '100%',
+            height: '100%',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            color: '#666',
+            background: '#1a1a1a',
+          }}
+        >
+          No video
+        </div>
+      )}
+      <div className="video-label">{label}</div>
+    </div>
+  );
+}

--- a/livekit-learning/next.config.ts
+++ b/livekit-learning/next.config.ts
@@ -1,0 +1,5 @@
+import type { NextConfig } from 'next';
+
+const nextConfig: NextConfig = {};
+
+export default nextConfig;

--- a/livekit-learning/package.json
+++ b/livekit-learning/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "livekit-learning",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev --turbopack -p 3001",
+    "build": "next build",
+    "start": "next start -p 3001"
+  },
+  "dependencies": {
+    "livekit-client": "^2.15.15",
+    "livekit-server-sdk": "^2.13.2",
+    "next": "15.5.8",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
+    "typescript": "^5"
+  },
+  "packageManager": "pnpm@9.15.9"
+}

--- a/livekit-learning/tsconfig.json
+++ b/livekit-learning/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": { "@/*": ["./*"] }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This commit introduces a comprehensive LiveKit learning environment:

- Add CLAUDE.md with project guidance for Claude Code
- Add Docs/PLAN.md with 14-step learning journey covering:
  - Project setup (packages, config)
  - Token authentication (JWT, grants)
  - UI components (ConnectionStatus, VideoTile)
  - Room connection (events, participants)
  - Testing and verification
  - Agent integration review

- Add livekit-learning/ folder with:
  - Minimal Next.js app demonstrating LiveKit concepts
  - Token generation API endpoint
  - Room page with event logging
  - Quiz system for self-assessment

- Add .claude/skills/generate-quiz skill for automatic quiz generation