### PR TITLE
fix: pointer event none on tile view

### DIFF
--- a/components/app/tile-layout.tsx
+++ b/components/app/tile-layout.tsx
@@ -92,7 +92,7 @@ export function TileLayout({ chatOpen, appConfig }: TileLayoutProps) {
   const videoHeight = agentVideoTrack?.publication.dimensions?.height ?? 0;
 
   return (
-    <div className="fixed inset-x-0 top-8 bottom-32 z-50 md:top-12 md:bottom-40">
+    <div className="pointer-events-none fixed inset-x-0 top-8 bottom-32 z-50 md:top-12 md:bottom-40">
       <div className="relative mx-auto h-full max-w-2xl px-4 md:px-0">
         <div className={cn(classNames.grid)}>
           {/* Agent */}


### PR DESCRIPTION
## Issue

the tile view overlaps the transcript and makes it impossible to highlight or select text

## Solution

apply `pointer-events-none` to tile view root