### PR TITLE
Fix lint warnings and remove unused code

### DIFF
--- a/components/agents-ui/agent-audio-visualizer-aura.tsx
+++ b/components/agents-ui/agent-audio-visualizer-aura.tsx
@@ -34,7 +34,8 @@ function hexToRgb(hexColor: string) {
     }
   } catch (error) {
     console.error(
-      `Invalid hex color '${hexColor}'.\nFalling back to default color '${DEFAULT_COLOR}'.`
+      `Invalid hex color '${hexColor}'.\nFalling back to default color '${DEFAULT_COLOR}'.`,
+      error
     );
   }
 

--- a/components/agents-ui/agent-audio-visualizer-radial.tsx
+++ b/components/agents-ui/agent-audio-visualizer-radial.tsx
@@ -138,7 +138,7 @@ export function AgentAudioVisualizerRadial({
       default:
         return 1000;
     }
-  }, [state, _barCount]);
+  }, [state]);
 
   const distanceFromCenter = useMemo(() => {
     if (radius) {

--- a/components/agents-ui/react-shader-toy.tsx
+++ b/components/agents-ui/react-shader-toy.tsx
@@ -143,10 +143,6 @@ const uniformTypeToGLSLType = (t: string) => {
 const LinearFilter = 9729;
 const NearestFilter = 9728;
 const LinearMipMapLinearFilter = 9987;
-const NearestMipMapLinearFilter = 9986;
-const LinearMipMapNearestFilter = 9985;
-const NearestMipMapNearestFilter = 9984;
-const MirroredRepeatWrapping = 33648;
 const ClampToEdgeWrapping = 33071;
 const RepeatWrapping = 10497;
 

--- a/components/ai-elements/message.tsx
+++ b/components/ai-elements/message.tsx
@@ -183,8 +183,8 @@ export type MessageBranchSelectorProps = HTMLAttributes<HTMLDivElement> & {
 };
 
 export const MessageBranchSelector = ({
-  className,
-  from,
+  className: _className,
+  from: _from,
   ...props
 }: MessageBranchSelectorProps) => {
   const { totalBranches } = useMessageBranch();


### PR DESCRIPTION
Small fixes for some lint issues I noticed while building:

- Remove unused WebGL constants
- Log caught error in hex color parsing
- Remove extra useMemo dependency
- Prefix unused props with underscore