### PR TITLE
fix: fixed typo in README about Shadcn components

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ See [`components/app/app.tsx`](./components/app/app.tsx) for an example of how t
 
 ### Customizing components
 
-Agents UI components, like most Shadcn compopnents, take as many primitive attributes as possible. For example, the [AgentControlBar](/reference/components/shadcn/component/agent-control-bar/page.mdoc) component extends `HTMLAttributes<HTMLDivElement>`, so you can pass any props that a div supports. This makes it easy to extend the component with your own styles or functionality.
+Agents UI components, like most Shadcn components, take as many primitive attributes as possible. For example, the [AgentControlBar](/reference/components/shadcn/component/agent-control-bar/page.mdoc) component extends `HTMLAttributes<HTMLDivElement>`, so you can pass any props that a div supports. This makes it easy to extend the component with your own styles or functionality.
 
 You can edit any Agents UI component's source code in the `components/agents-ui` directory. For style changes, we recommend passing in tailwind classes to override the default styles. Take a look at the source code to get a sense of how to override a component's default styles.
 


### PR DESCRIPTION
Fixed small typo in the README.md project file.

From compopnents to the expected components word