### PR TITLE
Guard persistent user choices storage access

### DIFF
--- a/hooks/agents-ui/use-agent-control-bar.ts
+++ b/hooks/agents-ui/use-agent-control-bar.ts
@@ -22,6 +22,18 @@ const trackSourceToProtocol = (source: Track.Source) => {
   }
 };
 
+const canAccessLocalStorage = () => {
+  try {
+    if (typeof window === 'undefined') {
+      return false;
+    }
+    window.localStorage.getItem('__lk_storage_check__');
+    return true;
+  } catch {
+    return false;
+  }
+};
+
 export interface PublishPermissions {
   camera: boolean;
   microphone: boolean;
@@ -93,7 +105,7 @@ export function useInputControls({
     saveVideoInputEnabled,
     saveAudioInputDeviceId,
     saveVideoInputDeviceId,
-  } = usePersistentUserChoices({ preventSave: !saveUserChoices });
+  } = usePersistentUserChoices({ preventSave: !saveUserChoices || !canAccessLocalStorage() });
 
   const handleAudioDeviceChange = useCallback(
     (deviceId: string) => {


### PR DESCRIPTION
## Summary
- Check whether `localStorage` is accessible before enabling persistent user choices.
- Preserve saved device preferences in normal browser contexts.
- Avoid runtime `SecurityError` crashes in contexts where storage access is denied.

## Verification
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/prettier --check hooks/agents-ui/use-agent-control-bar.ts`

Refs #339