### PR TITLE
Fix typo in env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# Enviroment variables needed to connect to the LiveKit server.
+# Environment variables needed to connect to the LiveKit server.
 LIVEKIT_API_KEY=<your_api_key>
 LIVEKIT_API_SECRET=<your_api_secret>
 LIVEKIT_URL=wss://<project-subdomain>.livekit.cloud


### PR DESCRIPTION
## Summary
- Fix `Enviroment` to `Environment` in `.env.example`.

## Verification
- Docs-only typo fix; no runtime changes.